### PR TITLE
feat: Context Hygiene CI + Archive Structure

### DIFF
--- a/.github/workflows/squad-size-check.yml
+++ b/.github/workflows/squad-size-check.yml
@@ -1,0 +1,33 @@
+name: Squad Size Check
+on:
+  pull_request:
+    paths: ['.squad/**']
+
+jobs:
+  check-sizes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check .squad/ file sizes
+        run: |
+          fail=0
+          total=0
+          while IFS= read -r -d '' f; do
+            size=$(stat -c%s "$f")
+            kb=$((size / 1024))
+            total=$((total + size))
+            if [ "$kb" -ge 15 ]; then
+              echo "::error file=$f::🛑 $f is ${kb}KB (limit: 15KB)"
+              fail=1
+            elif [ "$kb" -ge 12 ]; then
+              echo "::warning file=$f::⚠️ $f is ${kb}KB (approaching 15KB limit)"
+            fi
+          done < <(find .squad -type f ! -path '.squad/archive/*' ! -path '.squad/templates/*' -print0)
+
+          total_kb=$((total / 1024))
+          echo "Total .squad/ size: ${total_kb}KB"
+          if [ "$total_kb" -ge 100 ]; then
+            echo "::error::🛑 Total .squad/ is ${total_kb}KB (limit: 100KB)"
+            fail=1
+          fi
+          exit $fail

--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -11,4 +11,5 @@
 
 ## Learnings
 
-<!-- Append entries below as you learn about the project -->
+- 2026-03-13: Created squad-size-check.yml GitHub Action (34 lines, bash, no deps). Excludes archive/ and templates/ from checks.
+- 2026-03-13: `.squad/templates/squad.agent.TEMPLATE.md` is 71KB — framework scaffolding, not agent context. Excluded from CI.

--- a/.squad/archive/README.md
+++ b/.squad/archive/README.md
@@ -1,0 +1,7 @@
+# Squad Archive
+
+Archived `.squad/` content lives here. Old decisions, summarized history, and pruned logs.
+
+**Agents do NOT read archive files.** This directory is for human reference only.
+
+Files are moved here by Scribe during summarization/archival per `skills/context-hygiene/SKILL.md`.


### PR DESCRIPTION
## Context Hygiene System — CI & Archive

Closes #2

### Changes
- **GitHub Action** (\.github/workflows/squad-size-check.yml\): 34-line bash workflow that checks \.squad/\ file sizes on PRs
  - 🛑 FAIL if any file > 15KB
  - ⚠️ WARN if any file > 12KB  
  - 🛑 FAIL if total \.squad/\ > 100KB
  - Excludes \rchive/\ and \	emplates/\ (not agent working context)
- **Archive directory** (\.squad/archive/README.md\): Storage for archived content. Agents do NOT read archives.

### Validation Results
All operational \.squad/\ files are under limits. Largest operational file: \decisions.md\ at 5.6KB.

Note: \.squad/templates/squad.agent.TEMPLATE.md\ (71KB) is framework scaffolding, excluded from CI checks.