### PR TITLE
fix: sync-squad-labels parser over-reads into sub-sections

### DIFF
--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -43,12 +43,13 @@ jobs:
                 inMembersTable = true;
                 continue;
               }
-              if (inMembersTable && line.startsWith('## ')) {
-                break;
+              if (inMembersTable && line.match(/^#{2,}\s/)) {
+                break;  // stop at any heading (##, ###, etc.)
               }
               if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
                 const cells = line.split('|').map(c => c.trim()).filter(Boolean);
-                if (cells.length >= 2 && cells[0] !== 'Scribe') {
+                const skipNames = ['Scribe', '@copilot'];
+                if (cells.length >= 2 && !skipNames.includes(cells[0])) {
                   members.push({
                     name: cells[0],
                     role: cells[1]
@@ -131,6 +132,13 @@ jobs:
             labels.push(...TYPE_LABELS);
             labels.push(...PRIORITY_LABELS);
             labels.push(...SIGNAL_LABELS);
+
+            // Truncate descriptions to GitHub's 100-char limit
+            for (const label of labels) {
+              if (label.description && label.description.length > 100) {
+                label.description = label.description.substring(0, 97) + '...';
+              }
+            }
 
             // Sync labels (create or update)
             for (const label of labels) {


### PR DESCRIPTION
Closes #16

## Root Cause

The Members table parser used \line.startsWith('## ')\ to detect section boundaries, but \.squad/team.md\ has a \### @copilot Capability Profile\ sub-section inside Members. The parser continued into that table, picking up \Fit\, \🟢 Good\, \🟡 Review\, \🔴 Not suitable\ as squad members. The generated descriptions for those junk entries exceeded GitHub's 100-character label description limit, causing a 422 Validation Failed error.

## Fixes

1. **Heading detection** — break on any heading level (\/^#{2,}\s/\) not just \## \
2. **Skip \@copilot\** — already handled via \hasCopilot\ logic; prevents duplicate \squad:@copilot\ / \squad:copilot\ labels
3. **Description truncation** — guard against GitHub's 100-char limit for all labels