### PR TITLE
feat: add ralph-watch monitoring dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:validate-squad": "node scripts/validate-squad.js",
-    "check:constellation": "node scripts/constellation-health.js"
+    "check:constellation": "node scripts/constellation-health.js",
+    "dashboard:ralph": "node scripts/parse-ralph-logs.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/parse-ralph-logs.js
+++ b/scripts/parse-ralph-logs.js
@@ -1,0 +1,247 @@
+/**
+ * parse-ralph-logs.js — Ralph-Watch Log Parser & Dashboard Server
+ *
+ * Parses ralph-watch.ps1 log files from .squad/ralph-watch/ and serves
+ * the monitoring dashboard at http://localhost:3838.
+ *
+ * Usage:
+ *   node scripts/parse-ralph-logs.js          # Start dashboard server
+ *   node scripts/parse-ralph-logs.js --json   # Output parsed JSON to stdout
+ */
+
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+
+const LOG_DIR = path.join(process.cwd(), '.squad', 'ralph-watch');
+const HEARTBEAT_FILE = path.join(LOG_DIR, 'heartbeat.txt');
+const STATE_FILE = path.join(LOG_DIR, 'state.json');
+const SITE_DIR = path.join(process.cwd(), 'site');
+const PORT = 3838;
+const TAIL_LINES = 100;
+
+const LOG_LINE_RE = /^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\] \[(\w+)\] (.+)$/;
+
+/**
+ * Find the most recent log file(s) in the log directory.
+ */
+function findLogFiles() {
+  if (!fs.existsSync(LOG_DIR)) return [];
+  return fs.readdirSync(LOG_DIR)
+    .filter(f => f.endsWith('.log'))
+    .sort()
+    .reverse();
+}
+
+/**
+ * Read the last N lines from a file.
+ */
+function tailFile(filePath, lines) {
+  if (!fs.existsSync(filePath)) return [];
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const allLines = content.split(/\r?\n/).filter(l => l.trim());
+  return allLines.slice(-lines);
+}
+
+/**
+ * Parse a single log line into a structured entry.
+ */
+function parseLogLine(line) {
+  const match = line.match(LOG_LINE_RE);
+  if (!match) return null;
+  return { timestamp: match[1], level: match[2], message: match[3] };
+}
+
+/**
+ * Read and parse the heartbeat file.
+ */
+function readHeartbeat() {
+  try {
+    if (!fs.existsSync(HEARTBEAT_FILE)) return null;
+    return JSON.parse(fs.readFileSync(HEARTBEAT_FILE, 'utf-8'));
+  } catch { return null; }
+}
+
+/**
+ * Read and parse the state file.
+ */
+function readState() {
+  try {
+    if (!fs.existsSync(STATE_FILE)) return null;
+    return JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
+  } catch { return null; }
+}
+
+/**
+ * Parse the last 100 lines from the most recent log files
+ * and extract dashboard metrics.
+ */
+function parseLogs() {
+  const logFiles = findLogFiles();
+  const logDir = LOG_DIR;
+
+  // Collect last 100 lines across log files (most recent first)
+  let lines = [];
+  for (const file of logFiles) {
+    if (lines.length >= TAIL_LINES) break;
+    const remaining = TAIL_LINES - lines.length;
+    const filePath = path.join(logDir, file);
+    const fileLines = tailFile(filePath, remaining);
+    lines = fileLines.concat(lines);
+  }
+
+  // Keep only the last 100
+  lines = lines.slice(-TAIL_LINES);
+
+  const entries = lines.map(parseLogLine).filter(Boolean);
+
+  // Extract metrics
+  const lastEntry = entries.length > 0 ? entries[entries.length - 1] : null;
+  const lastRunTimestamp = lastEntry ? lastEntry.timestamp : 'No data';
+
+  // Repos monitored: scan all entries in the most recent log file for config info
+  let reposMonitored = [];
+  if (logFiles.length > 0) {
+    const fullPath = path.join(logDir, logFiles[0]);
+    const allFileLines = fs.readFileSync(fullPath, 'utf-8')
+      .split(/\r?\n/).filter(l => l.trim());
+    for (const line of allFileLines) {
+      const parsed = parseLogLine(line);
+      if (!parsed) continue;
+      const repoMatch = parsed.message.match(/^Monitoring (\d+) repositories: (.+)$/);
+      if (repoMatch) {
+        reposMonitored = repoMatch[2].split(', ').map(r => r.trim());
+      }
+    }
+  }
+
+  // Also check the last 100 entries as fallback
+  if (reposMonitored.length === 0) {
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const msg = entries[i].message;
+      const repoMatch = msg.match(/^Monitoring (\d+) repositories: (.+)$/);
+      if (repoMatch) {
+        reposMonitored = repoMatch[2].split(', ').map(r => r.trim());
+        break;
+      }
+    }
+  }
+
+  // Refueling events: lines with "Refueling" or "refueling" or "refuel"
+  const refuelingEvents = entries.filter(e =>
+    /refuel/i.test(e.message) || /Starting refueling/i.test(e.message)
+  );
+
+  // Error count
+  const errors = entries.filter(e => e.level === 'ERROR');
+  const warnings = entries.filter(e => e.level === 'WARN');
+  const successes = entries.filter(e => e.level === 'SUCCESS');
+
+  // Round info
+  const rounds = entries.filter(e => /^=== Round \d+ started ===$/.test(e.message));
+  const lastRound = rounds.length > 0 ? rounds[rounds.length - 1] : null;
+  const lastRoundNumber = lastRound
+    ? lastRound.message.match(/Round (\d+)/)?.[1] || '?'
+    : '0';
+
+  // Heartbeat & state
+  const heartbeat = readHeartbeat();
+  const state = readState();
+
+  return {
+    generatedAt: new Date().toISOString(),
+    lastRunTimestamp,
+    reposMonitored,
+    repoCount: reposMonitored.length,
+    lastRoundNumber,
+    totalRounds: rounds.length,
+    refuelingEvents: refuelingEvents.slice(-10).map(e => ({
+      timestamp: e.timestamp,
+      message: e.message
+    })),
+    errorCount: errors.length,
+    warningCount: warnings.length,
+    successCount: successes.length,
+    recentErrors: errors.slice(-5).map(e => ({
+      timestamp: e.timestamp,
+      message: e.message
+    })),
+    heartbeat: heartbeat ? {
+      timestamp: heartbeat.timestamp,
+      status: heartbeat.status,
+      version: heartbeat.version
+    } : null,
+    consecutiveFailures: state?.consecutive_failures ?? 0,
+    lastSuccess: state?.last_success ?? null,
+    logFilesFound: logFiles.length,
+    entriesParsed: entries.length,
+    recentEntries: entries.slice(-20).map(e => ({
+      timestamp: e.timestamp,
+      level: e.level,
+      message: e.message
+    }))
+  };
+}
+
+/**
+ * Serve the dashboard on a local HTTP server.
+ */
+function startServer() {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/api/status') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(parseLogs(), null, 2));
+      return;
+    }
+
+    if (req.url === '/styles/dashboard.css') {
+      const cssPath = path.join(SITE_DIR, 'styles', 'dashboard.css');
+      if (fs.existsSync(cssPath)) {
+        res.writeHead(200, { 'Content-Type': 'text/css' });
+        res.end(fs.readFileSync(cssPath, 'utf-8'));
+      } else {
+        res.writeHead(404);
+        res.end('Not found');
+      }
+      return;
+    }
+
+    if (req.url === '/' || req.url === '/index.html') {
+      const htmlPath = path.join(SITE_DIR, 'ralph-watch-status.html');
+      if (fs.existsSync(htmlPath)) {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(fs.readFileSync(htmlPath, 'utf-8'));
+      } else {
+        res.writeHead(404);
+        res.end('Dashboard HTML not found');
+      }
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('Not found');
+  });
+
+  server.listen(PORT, () => {
+    const url = `http://localhost:${PORT}`;
+    console.log(`\n  ⚡ Ralph-Watch Dashboard running at ${url}\n`);
+
+    // Open browser
+    const { exec } = require('child_process');
+    const cmd = process.platform === 'win32' ? `start ${url}`
+      : process.platform === 'darwin' ? `open ${url}`
+      : `xdg-open ${url}`;
+    exec(cmd);
+  });
+}
+
+// CLI entry point
+if (require.main === module) {
+  if (process.argv.includes('--json')) {
+    console.log(JSON.stringify(parseLogs(), null, 2));
+  } else {
+    startServer();
+  }
+}
+
+module.exports = { parseLogs, parseLogLine, findLogFiles, tailFile };

--- a/site/ralph-watch-status.html
+++ b/site/ralph-watch-status.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ralph-Watch Dashboard — Syntax Sorcery</title>
+  <link rel="stylesheet" href="/styles/dashboard.css" />
+</head>
+<body>
+  <div class="container">
+    <!-- Header -->
+    <header class="dashboard-header">
+      <h1>⚡ Ralph-Watch Dashboard</h1>
+      <p class="subtitle">Layer 2 Refueling Engine — Live Monitoring</p>
+      <div class="refresh-badge">
+        <span class="dot"></span>
+        <span id="refresh-status">Auto-refresh every 30s</span>
+      </div>
+    </header>
+
+    <!-- Heartbeat Bar -->
+    <div class="heartbeat-bar" id="heartbeat-bar">
+      <span class="status-dot status-unknown" id="heartbeat-dot"></span>
+      <span id="heartbeat-text">Loading heartbeat...</span>
+    </div>
+
+    <!-- Stats Grid -->
+    <div class="stats-grid" id="stats-grid">
+      <div class="stat-card">
+        <div class="value value-cyan" id="stat-last-run">--</div>
+        <div class="label">Last Run</div>
+        <div class="detail" id="stat-last-run-detail"></div>
+      </div>
+      <div class="stat-card">
+        <div class="value value-blue" id="stat-repos">0</div>
+        <div class="label">Repos Monitored</div>
+        <div class="detail" id="stat-repos-detail"></div>
+      </div>
+      <div class="stat-card">
+        <div class="value value-green" id="stat-refuels">0</div>
+        <div class="label">Refueling Events</div>
+        <div class="detail" id="stat-refuels-detail"></div>
+      </div>
+      <div class="stat-card">
+        <div class="value value-red" id="stat-errors">0</div>
+        <div class="label">Errors</div>
+        <div class="detail" id="stat-errors-detail"></div>
+      </div>
+    </div>
+
+    <!-- Repos Monitored -->
+    <div class="section">
+      <h2 class="section-title">📡 Repositories Monitored</h2>
+      <div class="repo-grid" id="repo-list">
+        <div class="empty-state">
+          <div class="empty-icon">📭</div>
+          <p>No repository data available</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Recent Refueling Events -->
+    <div class="section">
+      <h2 class="section-title">⛽ Recent Refueling Events</h2>
+      <div class="event-list" id="refuel-list">
+        <div class="empty-state">
+          <div class="empty-icon">⏳</div>
+          <p>No refueling events recorded</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Recent Errors -->
+    <div class="section">
+      <h2 class="section-title">🚨 Recent Errors</h2>
+      <div class="event-list" id="error-list">
+        <div class="empty-state">
+          <div class="empty-icon">✅</div>
+          <p>No errors — all clear</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Live Log Feed -->
+    <div class="section">
+      <h2 class="section-title">📋 Recent Log Entries</h2>
+      <div class="log-feed" id="log-feed">
+        <div class="empty-state">
+          <div class="empty-icon">📄</div>
+          <p>Waiting for log data...</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="dashboard-footer">
+      <p>Syntax Sorcery — Autonomous Software Company</p>
+      <p>Ralph-Watch v1.0.0 • Layer 2 Refueling Engine • Data from .squad/ralph-watch/ logs</p>
+    </footer>
+  </div>
+
+  <script>
+    const REFRESH_INTERVAL = 30000; // 30 seconds
+    let refreshTimer = null;
+    let countdown = 30;
+
+    function escapeHtml(str) {
+      const div = document.createElement('div');
+      div.textContent = str;
+      return div.innerHTML;
+    }
+
+    function formatTimestamp(ts) {
+      if (!ts || ts === 'No data') return 'No data';
+      // Handle ISO format
+      if (ts.includes('T')) {
+        const d = new Date(ts);
+        return d.toLocaleString();
+      }
+      return ts;
+    }
+
+    function timeAgo(ts) {
+      if (!ts || ts === 'No data') return '';
+      let d;
+      if (ts.includes('T')) {
+        d = new Date(ts);
+      } else {
+        // Parse "YYYY-MM-DD HH:MM:SS" format
+        d = new Date(ts.replace(' ', 'T'));
+      }
+      const now = new Date();
+      const diffMs = now - d;
+      const diffMin = Math.floor(diffMs / 60000);
+      if (diffMin < 1) return 'just now';
+      if (diffMin < 60) return `${diffMin}m ago`;
+      const diffHr = Math.floor(diffMin / 60);
+      if (diffHr < 24) return `${diffHr}h ago`;
+      const diffDay = Math.floor(diffHr / 24);
+      return `${diffDay}d ago`;
+    }
+
+    function renderStats(data) {
+      // Last run
+      document.getElementById('stat-last-run').textContent =
+        data.lastRunTimestamp === 'No data' ? '--' : formatTimestamp(data.lastRunTimestamp);
+      document.getElementById('stat-last-run-detail').textContent =
+        timeAgo(data.lastRunTimestamp);
+
+      // Repos
+      document.getElementById('stat-repos').textContent = data.repoCount;
+      document.getElementById('stat-repos-detail').textContent =
+        `Round ${data.lastRoundNumber} (${data.totalRounds} total)`;
+
+      // Refuels
+      document.getElementById('stat-refuels').textContent = data.refuelingEvents.length;
+      document.getElementById('stat-refuels-detail').textContent =
+        `${data.successCount} successes in log window`;
+
+      // Errors
+      document.getElementById('stat-errors').textContent = data.errorCount;
+      const errClass = data.errorCount > 0 ? 'value-red' : 'value-green';
+      const errEl = document.getElementById('stat-errors');
+      errEl.className = 'value ' + errClass;
+      document.getElementById('stat-errors-detail').textContent =
+        `${data.warningCount} warnings`;
+    }
+
+    function renderHeartbeat(data) {
+      const dot = document.getElementById('heartbeat-dot');
+      const text = document.getElementById('heartbeat-text');
+
+      if (!data.heartbeat) {
+        dot.className = 'status-dot status-unknown';
+        text.textContent = 'No heartbeat data — ralph-watch may not be running';
+        return;
+      }
+
+      const hb = data.heartbeat;
+      const ago = timeAgo(hb.timestamp);
+
+      // If heartbeat is older than 30 minutes, consider stopped
+      const hbDate = new Date(hb.timestamp);
+      const diffMs = Date.now() - hbDate.getTime();
+      const isRecent = diffMs < 30 * 60 * 1000;
+
+      if (hb.status === 'running' && isRecent) {
+        dot.className = 'status-dot status-running';
+        text.textContent = `Running (v${hb.version}) — last heartbeat ${ago}`;
+      } else if (hb.status === 'running') {
+        dot.className = 'status-dot status-stopped';
+        text.textContent = `Likely stopped — last heartbeat ${ago}`;
+      } else {
+        dot.className = 'status-dot status-unknown';
+        text.textContent = `Status: ${hb.status} — last heartbeat ${ago}`;
+      }
+
+      if (data.consecutiveFailures > 0) {
+        text.textContent += ` | ⚠️ ${data.consecutiveFailures} consecutive failure(s)`;
+      }
+    }
+
+    function renderRepos(data) {
+      const container = document.getElementById('repo-list');
+      if (data.reposMonitored.length === 0) {
+        container.innerHTML = '<div class="empty-state"><div class="empty-icon">📭</div><p>No repository data available</p></div>';
+        return;
+      }
+      container.innerHTML = data.reposMonitored.map(repo => `
+        <div class="repo-item">
+          <span class="repo-icon">📦</span>
+          <span class="repo-name">${escapeHtml(repo)}</span>
+        </div>
+      `).join('');
+    }
+
+    function renderRefuels(data) {
+      const container = document.getElementById('refuel-list');
+      if (data.refuelingEvents.length === 0) {
+        container.innerHTML = '<div class="empty-state"><div class="empty-icon">⏳</div><p>No refueling events in the last 100 log lines</p></div>';
+        return;
+      }
+      container.innerHTML = data.refuelingEvents.map(e => `
+        <div class="event-item event-success">
+          <span class="event-time">${escapeHtml(e.timestamp)}</span>
+          <span class="event-msg">${escapeHtml(e.message)}</span>
+        </div>
+      `).join('');
+    }
+
+    function renderErrors(data) {
+      const container = document.getElementById('error-list');
+      if (data.recentErrors.length === 0) {
+        container.innerHTML = '<div class="empty-state"><div class="empty-icon">✅</div><p>No errors — all clear</p></div>';
+        return;
+      }
+      container.innerHTML = data.recentErrors.map(e => `
+        <div class="event-item event-error">
+          <span class="event-time">${escapeHtml(e.timestamp)}</span>
+          <span class="event-msg">${escapeHtml(e.message)}</span>
+        </div>
+      `).join('');
+    }
+
+    function renderLogFeed(data) {
+      const container = document.getElementById('log-feed');
+      if (data.recentEntries.length === 0) {
+        container.innerHTML = '<div class="empty-state"><div class="empty-icon">📄</div><p>No log entries found</p></div>';
+        return;
+      }
+      container.innerHTML = data.recentEntries.map(e => `
+        <div class="log-line">
+          <span class="log-ts">${escapeHtml(e.timestamp)}</span>
+          <span class="log-level log-level-${e.level}">[${e.level}]</span>
+          <span class="log-msg">${escapeHtml(e.message)}</span>
+        </div>
+      `).join('');
+      // Auto-scroll to bottom
+      container.scrollTop = container.scrollHeight;
+    }
+
+    async function fetchAndRender() {
+      try {
+        const res = await fetch('/api/status');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+
+        renderStats(data);
+        renderHeartbeat(data);
+        renderRepos(data);
+        renderRefuels(data);
+        renderErrors(data);
+        renderLogFeed(data);
+
+        document.getElementById('refresh-status').textContent =
+          `Last updated: ${new Date().toLocaleTimeString()} • Auto-refresh every 30s`;
+      } catch (err) {
+        console.error('Failed to fetch status:', err);
+        document.getElementById('refresh-status').textContent =
+          `⚠️ Fetch failed: ${err.message} — retrying in 30s`;
+      }
+    }
+
+    // Initial load
+    fetchAndRender();
+
+    // Auto-refresh every 30 seconds
+    setInterval(fetchAndRender, REFRESH_INTERVAL);
+  </script>
+</body>
+</html>

--- a/site/styles/dashboard.css
+++ b/site/styles/dashboard.css
@@ -1,0 +1,309 @@
+/* dashboard.css — Ralph-Watch Dashboard Styling
+ * Matches Syntax Sorcery dark theme (gray-950 bg, cyan/blue accents)
+ */
+
+:root {
+  --bg-primary: #030712;    /* gray-950 */
+  --bg-card: #111827;       /* gray-900 */
+  --bg-card-alt: #1f2937;   /* gray-800 */
+  --border: #374151;        /* gray-700 */
+  --text-primary: #f3f4f6;  /* gray-100 */
+  --text-secondary: #9ca3af;/* gray-400 */
+  --text-muted: #6b7280;    /* gray-500 */
+  --accent-cyan: #22d3ee;   /* cyan-400 */
+  --accent-blue: #2563eb;   /* blue-600 */
+  --accent-green: #4ade80;  /* green-400 */
+  --accent-red: #f87171;    /* red-400 */
+  --accent-yellow: #facc15; /* yellow-400 */
+  --font-mono: 'Cascadia Code', 'Fira Code', 'JetBrains Mono', monospace;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+/* Header */
+.dashboard-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.dashboard-header h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  background: linear-gradient(to right, var(--accent-cyan), var(--accent-blue));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.5rem;
+}
+
+.dashboard-header .subtitle {
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+}
+
+.refresh-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  padding: 0.35rem 1rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.refresh-badge .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-green);
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* Status Cards Grid */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.stat-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  text-align: center;
+  transition: border-color 0.2s;
+}
+
+.stat-card:hover {
+  border-color: var(--accent-cyan);
+}
+
+.stat-card .value {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.stat-card .label {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.stat-card .detail {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.value-cyan { color: var(--accent-cyan); }
+.value-green { color: var(--accent-green); }
+.value-red { color: var(--accent-red); }
+.value-yellow { color: var(--accent-yellow); }
+.value-blue { color: var(--accent-blue); }
+
+/* Sections */
+.section {
+  margin-bottom: 2rem;
+}
+
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+/* Repo List */
+.repo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.75rem;
+}
+
+.repo-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.repo-item .repo-icon {
+  font-size: 1.25rem;
+}
+
+.repo-item .repo-name {
+  color: var(--accent-cyan);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+}
+
+/* Event List */
+.event-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.event-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.event-item .event-time {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  white-space: nowrap;
+  min-width: 140px;
+}
+
+.event-item .event-msg {
+  color: var(--text-secondary);
+}
+
+.event-item.event-error {
+  border-left: 3px solid var(--accent-red);
+}
+
+.event-item.event-success {
+  border-left: 3px solid var(--accent-green);
+}
+
+.event-item.event-warn {
+  border-left: 3px solid var(--accent-yellow);
+}
+
+/* Log Feed */
+.log-feed {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  max-height: 400px;
+  overflow-y: auto;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.8;
+}
+
+.log-line {
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.25rem;
+}
+
+.log-line:hover {
+  background: var(--bg-card-alt);
+}
+
+.log-line .log-ts {
+  color: var(--text-muted);
+}
+
+.log-line .log-level {
+  font-weight: 600;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.2rem;
+  font-size: 0.75rem;
+}
+
+.log-level-INFO { color: var(--accent-cyan); }
+.log-level-SUCCESS { color: var(--accent-green); }
+.log-level-WARN { color: var(--accent-yellow); }
+.log-level-ERROR { color: var(--accent-red); }
+
+.log-line .log-msg {
+  color: var(--text-secondary);
+}
+
+/* Empty state */
+.empty-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--text-muted);
+}
+
+.empty-state .empty-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+/* Heartbeat indicator */
+.heartbeat-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 0.75rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  margin-bottom: 2rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.heartbeat-bar .status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.status-running { background: var(--accent-green); animation: pulse 2s infinite; }
+.status-stopped { background: var(--accent-red); }
+.status-unknown { background: var(--accent-yellow); }
+
+/* Footer */
+.dashboard-footer {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .container { padding: 1rem; }
+  .dashboard-header h1 { font-size: 1.75rem; }
+  .stats-grid { grid-template-columns: repeat(2, 1fr); }
+  .repo-grid { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary

Adds a live monitoring dashboard for alph-watch.ps1 (Layer 2 Refueling Engine).

### New Files
- **site/ralph-watch-status.html** — Dashboard HTML with auto-refresh every 30s
- **site/styles/dashboard.css** — Dark theme matching Syntax Sorcery brand
- **scripts/parse-ralph-logs.js** — Log parser + local HTTP server (port 3838)

### What It Shows
- Last run timestamp
- Repositories monitored (parsed from logs)
- Recent refueling events
- Error & warning counts
- Heartbeat status (running/stopped)
- Live log feed (last 20 entries)

### Usage
\\\
npm run dashboard:ralph
\\\
Opens browser to http://localhost:3838 with live auto-refreshing dashboard.

Closes #29