### PR TITLE
feat: add issue dedup guard for perpetual motion

### DIFF
--- a/.squad/guides/dedup-guard.md
+++ b/.squad/guides/dedup-guard.md
@@ -1,0 +1,85 @@
+# Dedup Guard — Preventing Duplicate Planning Issues
+
+## Purpose
+
+The perpetual-motion workflow creates "Define next roadmap" issues when all roadmap items close. If multiple issues close in quick succession, the workflow can fire multiple times before the first new issue is created — resulting in duplicate planning issues.
+
+`scripts/dedup-guard.js` is a lightweight pre-check that queries GitHub for existing open issues matching the planning issue pattern before creating a new one.
+
+## How It Works
+
+1. Queries `gh issue list` for open issues with label `squad` and title containing "roadmap"
+2. If a match is found: logs the existing issue number and exits cleanly (code 0)
+3. If no match: logs "safe to create" and exits cleanly (code 0)
+4. On API error: exits with code 1
+
+## Usage
+
+### CLI
+
+```bash
+# Uses current repo context from gh CLI
+npm run dedup:check
+
+# Explicit owner/repo
+node scripts/dedup-guard.js --owner jperezdelreal --repo Syntax-Sorcery
+```
+
+### In Perpetual-Motion Workflows
+
+Add the dedup check as a step **before** the issue creation step in your workflow:
+
+```yaml
+- name: Check for existing planning issue
+  id: dedup
+  run: node scripts/dedup-guard.js --owner ${{ github.repository_owner }} --repo ${{ github.event.repository.name }}
+
+- name: Create planning issue
+  if: steps.dedup.outputs.duplicate != 'true'
+  run: |
+    gh issue create --title "Define next roadmap cycle" --label squad ...
+```
+
+Alternatively, capture the script output and parse it:
+
+```yaml
+- name: Check for duplicate
+  id: dedup
+  run: |
+    OUTPUT=$(node scripts/dedup-guard.js)
+    echo "$OUTPUT"
+    if echo "$OUTPUT" | grep -q "skipping"; then
+      echo "skip=true" >> $GITHUB_OUTPUT
+    fi
+
+- name: Create issue
+  if: steps.dedup.outputs.skip != 'true'
+  run: gh issue create ...
+```
+
+### Programmatic (Node.js)
+
+```js
+const { run } = require('./scripts/dedup-guard');
+
+const result = run(['node', 'script.js', '--owner', 'alice', '--repo', 'my-repo']);
+// result = { exitCode: 0, duplicate: true, issueNumber: 42 }
+```
+
+## Testing
+
+```bash
+npm test -- scripts/__tests__/dedup-guard.test.js
+```
+
+Tests mock `execSync` / `gh CLI` calls — no network access required. Covers:
+
+- Duplicate exists → skip
+- No duplicate → safe to create
+- API error → exitCode 1
+- Argument parsing (`--owner`, `--repo`)
+
+## Dependencies
+
+- **gh CLI** — must be installed and authenticated with `repo` scope
+- **Node.js** — CommonJS, no external dependencies

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "test:watch": "vitest",
     "test:validate-squad": "node scripts/validate-squad.js",
     "check:constellation": "node scripts/constellation-health.js",
-    "dashboard:ralph": "node scripts/parse-ralph-logs.js"
+    "dashboard:ralph": "node scripts/parse-ralph-logs.js",
+    "dedup:check": "node scripts/dedup-guard.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/__tests__/dedup-guard.test.js
+++ b/scripts/__tests__/dedup-guard.test.js
@@ -1,0 +1,187 @@
+/**
+ * Tests for scripts/dedup-guard.js
+ *
+ * Mocks execSync via the injected execFn parameter to avoid real gh CLI calls.
+ * Uses vitest globals mode (vi, describe, it, expect, beforeEach are global).
+ */
+
+const { run, findDuplicateIssues, parseArgs } = require('../dedup-guard');
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe('parseArgs', () => {
+  it('parses --owner and --repo flags', () => {
+    const result = parseArgs(['node', 'script.js', '--owner', 'alice', '--repo', 'my-repo']);
+    expect(result).toEqual({ owner: 'alice', repo: 'my-repo' });
+  });
+
+  it('returns nulls when no flags provided', () => {
+    const result = parseArgs(['node', 'script.js']);
+    expect(result).toEqual({ owner: null, repo: null });
+  });
+
+  it('handles partial flags (owner only)', () => {
+    const result = parseArgs(['node', 'script.js', '--owner', 'bob']);
+    expect(result).toEqual({ owner: 'bob', repo: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findDuplicateIssues
+// ---------------------------------------------------------------------------
+
+describe('findDuplicateIssues', () => {
+  it('returns parsed issues from gh CLI output', () => {
+    const mockExec = vi.fn().mockReturnValue(
+      JSON.stringify([{ number: 42, title: 'Define next roadmap cycle' }])
+    );
+    const result = findDuplicateIssues('alice', 'repo', mockExec);
+    expect(result).toEqual([{ number: 42, title: 'Define next roadmap cycle' }]);
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.stringContaining('gh issue list'),
+      expect.objectContaining({ encoding: 'utf8' })
+    );
+  });
+
+  it('returns empty array when no issues found', () => {
+    const mockExec = vi.fn().mockReturnValue('[]');
+    const result = findDuplicateIssues('alice', 'repo', mockExec);
+    expect(result).toEqual([]);
+  });
+
+  it('propagates exec errors', () => {
+    const mockExec = vi.fn().mockImplementation(() => {
+      throw new Error('gh not found');
+    });
+    expect(() => findDuplicateIssues('alice', 'repo', mockExec)).toThrow('gh not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run — duplicate exists (skip)
+// ---------------------------------------------------------------------------
+
+describe('run — duplicate exists', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs skip message and returns duplicate=true when open planning issue exists', () => {
+    const mockExec = vi.fn().mockReturnValue(
+      JSON.stringify([{ number: 99, title: 'Define next roadmap cycle' }])
+    );
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = run(
+      ['node', 'script.js', '--owner', 'alice', '--repo', 'my-repo'],
+      mockExec
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.duplicate).toBe(true);
+    expect(result.issueNumber).toBe(99);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Dedup: open planning issue already exists (#99), skipping'
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('uses first issue when multiple duplicates exist', () => {
+    const mockExec = vi.fn().mockReturnValue(
+      JSON.stringify([
+        { number: 10, title: 'Define next roadmap' },
+        { number: 20, title: 'Roadmap planning' },
+      ])
+    );
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = run(
+      ['node', 'script.js', '--owner', 'alice', '--repo', 'my-repo'],
+      mockExec
+    );
+
+    expect(result.duplicate).toBe(true);
+    expect(result.issueNumber).toBe(10);
+
+    consoleSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run — no duplicate (allow)
+// ---------------------------------------------------------------------------
+
+describe('run — no duplicate', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs safe-to-create message when no open planning issue exists', () => {
+    const mockExec = vi.fn().mockReturnValue('[]');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = run(
+      ['node', 'script.js', '--owner', 'alice', '--repo', 'my-repo'],
+      mockExec
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.duplicate).toBe(false);
+    expect(result.issueNumber).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Dedup: no open planning issue found, safe to create'
+    );
+
+    consoleSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run — API error handling
+// ---------------------------------------------------------------------------
+
+describe('run — API error handling', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns exitCode 1 and logs error on API failure', () => {
+    const mockExec = vi.fn().mockImplementation(() => {
+      throw new Error('HTTP 403: rate limit exceeded');
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = run(
+      ['node', 'script.js', '--owner', 'alice', '--repo', 'my-repo'],
+      mockExec
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.duplicate).toBe(false);
+    expect(result.issueNumber).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Dedup: API error')
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('returns exitCode 1 when repo cannot be resolved and no flags provided', () => {
+    const mockExec = vi.fn().mockImplementation(() => {
+      throw new Error('not a git repo');
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = run(['node', 'script.js'], mockExec);
+
+    expect(result.exitCode).toBe(1);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('could not resolve repo')
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/scripts/dedup-guard.js
+++ b/scripts/dedup-guard.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Dedup Guard — prevents perpetual-motion from creating duplicate planning issues.
+ *
+ * Checks if an open issue with label `squad` and a title containing "roadmap"
+ * already exists. Designed to run before creating a new planning issue.
+ *
+ * Usage:
+ *   node scripts/dedup-guard.js
+ *   node scripts/dedup-guard.js --owner jperezdelreal --repo Syntax-Sorcery
+ *
+ * Exit codes:
+ *   0 — always (duplicate found = skip, no duplicate = safe to create)
+ *   1 — API / runtime error
+ *
+ * Requires: gh CLI authenticated with repo scope.
+ */
+
+const { execSync } = require('child_process');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves owner/repo from gh CLI context when not provided via flags.
+ */
+function resolveRepo(execFn) {
+  const exec = execFn || execSync;
+  try {
+    const raw = exec('gh repo view --json nameWithOwner -q .nameWithOwner', {
+      encoding: 'utf8',
+      timeout: 15_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return raw.trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Searches for open issues with label `squad` and title containing "roadmap".
+ * Returns an array of matching issue objects ({ number, title }).
+ */
+function findDuplicateIssues(owner, repo, execFn) {
+  const exec = execFn || execSync;
+  const cmd = [
+    'gh', 'issue', 'list',
+    '--repo', `${owner}/${repo}`,
+    '--label', 'squad',
+    '--search', '"roadmap" in:title',
+    '--state', 'open',
+    '--json', 'number,title',
+  ].join(' ');
+
+  const raw = exec(cmd, {
+    encoding: 'utf8',
+    timeout: 15_000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  return JSON.parse(raw);
+}
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const result = { owner: null, repo: null };
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--owner' && args[i + 1]) {
+      result.owner = args[++i];
+    } else if (args[i] === '--repo' && args[i + 1]) {
+      result.repo = args[++i];
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function run(argv, execFn) {
+  const parsed = parseArgs(argv || process.argv);
+  let owner = parsed.owner;
+  let repo = parsed.repo;
+
+  // Resolve from gh context if not provided
+  if (!owner || !repo) {
+    const fullName = resolveRepo(execFn);
+    if (!fullName) {
+      console.error('Dedup: could not resolve repo — pass --owner and --repo flags');
+      return { exitCode: 1, duplicate: false, issueNumber: null };
+    }
+    const parts = fullName.split('/');
+    owner = owner || parts[0];
+    repo = repo || parts[1];
+  }
+
+  let issues;
+  try {
+    issues = findDuplicateIssues(owner, repo, execFn);
+  } catch (err) {
+    console.error(`Dedup: API error — ${err.message}`);
+    return { exitCode: 1, duplicate: false, issueNumber: null };
+  }
+
+  if (issues.length > 0) {
+    const num = issues[0].number;
+    console.log(`Dedup: open planning issue already exists (#${num}), skipping`);
+    return { exitCode: 0, duplicate: true, issueNumber: num };
+  }
+
+  console.log('Dedup: no open planning issue found, safe to create');
+  return { exitCode: 0, duplicate: false, issueNumber: null };
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+  const result = run();
+  process.exit(result.exitCode);
+}
+
+module.exports = { run, findDuplicateIssues, parseArgs, resolveRepo };


### PR DESCRIPTION
Adds scripts/dedup-guard.js - prevents perpetual-motion from creating duplicate planning issues.

- Queries GitHub for open issues with label squad and title containing roadmap
- If duplicate found: exits 0, logs skip message
- If no duplicate: exits 0, logs safe-to-create
- Accepts --owner and --repo flags
- 11 unit tests, all 137 tests pass
- Guide at .squad/guides/dedup-guard.md

Closes #36
