### PR TITLE
feat: add Azure satellite launcher scripts

### DIFF
--- a/scripts/azure/README.md
+++ b/scripts/azure/README.md
@@ -1,0 +1,125 @@
+# Azure Satellite Launcher
+
+Scripts to deploy and manage satellite Copilot CLI sessions on an Azure VM for the Syntax Sorcery constellation.
+
+## Architecture
+
+```
+Hub (local machine)
+  └── SSH → Azure VM (B2s v2, Ubuntu 24.04, West Europe)
+              └── tmux sessions (5 satellites)
+                    ├── sat-flora
+                    ├── sat-ComeRosquillas
+                    ├── sat-pixel-bounce
+                    ├── sat-ffs-squad-monitor
+                    └── sat-FirstFrameStudios
+```
+
+- **VM:** Standard_B2s_v2 (~€25-30/month)
+- **OS:** Ubuntu 24.04 LTS
+- **Terminal multiplexer:** tmux
+- **Auto-start:** systemd unit (`satellites.service`)
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `start-satellites.sh` | Launch tmux sessions for all 5 repos |
+| `reset-satellite.sh` | Kill and restart a single satellite by repo name |
+| `provision-vm.sh` | Azure CLI commands to provision the VM |
+| `satellites.service` | systemd unit for auto-start on boot |
+
+## Setup
+
+### 1. Provision the VM
+
+```bash
+./scripts/azure/provision-vm.sh
+```
+
+This creates the resource group, VM, installs dependencies (tmux, git, Node.js), and clones all 5 repos.
+
+### 2. Copy scripts to VM
+
+```bash
+scp -r scripts/azure/ ssadmin@<VM_IP>:~/scripts/azure/
+chmod +x ~/scripts/azure/*.sh
+```
+
+### 3. Install systemd service
+
+```bash
+sudo cp ~/scripts/azure/satellites.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable satellites.service
+sudo systemctl start satellites.service
+```
+
+### 4. Verify
+
+```bash
+# Check service status
+sudo systemctl status satellites.service
+
+# List tmux sessions
+tmux list-sessions
+
+# Attach to a satellite
+tmux attach -t sat-flora
+```
+
+## Usage
+
+### Start all satellites
+
+```bash
+./scripts/azure/start-satellites.sh
+```
+
+Idempotent — skips sessions that already exist.
+
+### Dry run (validate without launching)
+
+```bash
+./scripts/azure/start-satellites.sh --dry-run
+```
+
+Validates that all repo directories exist and `copilot` CLI is available.
+
+### Reset a single satellite
+
+```bash
+./scripts/azure/reset-satellite.sh flora
+./scripts/azure/reset-satellite.sh ComeRosquillas
+./scripts/azure/reset-satellite.sh pixel-bounce
+./scripts/azure/reset-satellite.sh ffs-squad-monitor
+./scripts/azure/reset-satellite.sh FirstFrameStudios
+```
+
+Kills the existing tmux session (if any) and starts a fresh one.
+
+### Attach to a satellite
+
+```bash
+tmux attach -t sat-flora
+# Detach with Ctrl+B, then D
+```
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `copilot` not found | Install: `npm install -g @githubnext/github-copilot-cli` |
+| Repo directory missing | Clone: `git clone https://github.com/jperezdelreal/<repo>.git ~/repos/<repo>` |
+| tmux session won't start | Check disk space: `df -h`, memory: `free -h` |
+| Service fails on boot | Check logs: `journalctl -u satellites.service -e` |
+| VM unreachable | Verify NSG rules allow SSH (port 22): `az vm open-port ...` |
+| Session stuck | Reset it: `./reset-satellite.sh <repo-name>` |
+| All sessions dead | Restart service: `sudo systemctl restart satellites.service` |
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SATELLITE_BASE_DIR` | `~/repos` | Base directory containing repo clones |
+| `SSH_KEY_PATH` | `~/.ssh/id_rsa.pub` | SSH public key for VM provisioning |

--- a/scripts/azure/provision-vm.sh
+++ b/scripts/azure/provision-vm.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# provision-vm.sh — Azure CLI commands to provision a B2s v2 VM for satellite operations
+# Budget: €25-30/mo | Region: West Europe | OS: Ubuntu 24.04 LTS
+# Idempotent: checks for existing resources before creating
+set -euo pipefail
+
+RESOURCE_GROUP="syntax-sorcery-satellites"
+VM_NAME="ss-satellite-vm"
+LOCATION="westeurope"
+VM_SIZE="Standard_B2s_v2"
+IMAGE="Canonical:ubuntu-24_04-lts:server:latest"
+ADMIN_USER="ssadmin"
+SSH_KEY_PATH="${SSH_KEY_PATH:-$HOME/.ssh/id_rsa.pub}"
+
+log() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"; }
+
+# Verify Azure CLI is available
+if ! command -v az &>/dev/null; then
+  log "ERROR: Azure CLI (az) not found. Install: https://aka.ms/InstallAzureCLI"
+  exit 1
+fi
+
+# Verify logged in
+if ! az account show &>/dev/null; then
+  log "ERROR: Not logged into Azure. Run: az login"
+  exit 1
+fi
+
+# Verify SSH key exists
+if [[ ! -f "$SSH_KEY_PATH" ]]; then
+  log "ERROR: SSH public key not found at $SSH_KEY_PATH"
+  log "Generate one with: ssh-keygen -t rsa -b 4096"
+  exit 1
+fi
+
+# Create resource group (idempotent)
+if az group show --name "$RESOURCE_GROUP" &>/dev/null; then
+  log "SKIP: resource group '$RESOURCE_GROUP' already exists"
+else
+  log "CREATE: resource group '$RESOURCE_GROUP' in $LOCATION"
+  az group create --name "$RESOURCE_GROUP" --location "$LOCATION" --output none
+fi
+
+# Create VM (idempotent)
+if az vm show --resource-group "$RESOURCE_GROUP" --name "$VM_NAME" &>/dev/null; then
+  log "SKIP: VM '$VM_NAME' already exists"
+else
+  log "CREATE: VM '$VM_NAME' (size: $VM_SIZE, image: Ubuntu 24.04)"
+  az vm create \
+    --resource-group "$RESOURCE_GROUP" \
+    --name "$VM_NAME" \
+    --location "$LOCATION" \
+    --size "$VM_SIZE" \
+    --image "$IMAGE" \
+    --admin-username "$ADMIN_USER" \
+    --ssh-key-value "@$SSH_KEY_PATH" \
+    --public-ip-sku Standard \
+    --nsg-rule SSH \
+    --output table
+fi
+
+# Open port 22 (idempotent — default NSG rule already allows SSH)
+log "VERIFY: SSH access enabled"
+az vm open-port \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$VM_NAME" \
+  --port 22 \
+  --priority 1000 \
+  --output none 2>/dev/null || true
+
+# Install dependencies on VM
+log "CONFIGURE: installing dependencies on VM"
+az vm run-command invoke \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$VM_NAME" \
+  --command-id RunShellScript \
+  --scripts '
+    set -e
+    apt-get update -qq
+    apt-get install -y -qq tmux git nodejs npm
+    npm install -g @githubnext/github-copilot-cli || true
+    # Clone repos
+    REPOS="flora ComeRosquillas pixel-bounce ffs-squad-monitor FirstFrameStudios"
+    mkdir -p /home/ssadmin/repos
+    cd /home/ssadmin/repos
+    for repo in $REPOS; do
+      if [ ! -d "$repo" ]; then
+        git clone "https://github.com/jperezdelreal/$repo.git" || true
+      fi
+    done
+    chown -R ssadmin:ssadmin /home/ssadmin/repos
+  ' \
+  --output table
+
+# Get public IP
+PUBLIC_IP=$(az vm show \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$VM_NAME" \
+  --show-details \
+  --query publicIps \
+  --output tsv)
+
+log "DONE: VM provisioned"
+log "  SSH: ssh $ADMIN_USER@$PUBLIC_IP"
+log "  Next: copy scripts/azure/ to VM, install satellites.service"
+log "  Cost estimate: ~€25-30/month for B2s v2 in West Europe"

--- a/scripts/azure/reset-satellite.sh
+++ b/scripts/azure/reset-satellite.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# reset-satellite.sh — Kill and restart a single satellite tmux session by repo name
+# Idempotent: works whether the session exists or not
+set -euo pipefail
+
+REPOS=(flora ComeRosquillas pixel-bounce ffs-squad-monitor FirstFrameStudios)
+BASE_DIR="${SATELLITE_BASE_DIR:-$HOME/repos}"
+
+usage() {
+  echo "Usage: $0 <repo-name>"
+  echo "  Repo must be one of: ${REPOS[*]}"
+  echo "  Kills existing tmux session (if any) and starts a fresh one."
+  exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+fi
+
+REPO="$1"
+
+# Validate repo name
+valid=false
+for r in "${REPOS[@]}"; do
+  if [[ "$r" == "$REPO" ]]; then
+    valid=true
+    break
+  fi
+done
+
+if ! $valid; then
+  echo "ERROR: '$REPO' is not a valid repo name."
+  echo "Valid repos: ${REPOS[*]}"
+  exit 1
+fi
+
+log() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"; }
+
+SESSION_NAME="sat-$REPO"
+REPO_DIR="$BASE_DIR/$REPO"
+
+if [[ ! -d "$REPO_DIR" ]]; then
+  log "ERROR: repo directory not found: $REPO_DIR"
+  exit 1
+fi
+
+# Kill existing session if present
+if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+  log "KILL: terminating session '$SESSION_NAME'"
+  tmux kill-session -t "$SESSION_NAME"
+  sleep 1
+fi
+
+# Start fresh session
+log "LAUNCH: creating tmux session '$SESSION_NAME'"
+tmux new-session -d -s "$SESSION_NAME" -c "$REPO_DIR"
+tmux send-keys -t "$SESSION_NAME" "copilot" Enter
+sleep 2
+tmux send-keys -t "$SESSION_NAME" "Ralph, go" Enter
+
+log "OK: session '$SESSION_NAME' restarted"

--- a/scripts/azure/satellites.service
+++ b/scripts/azure/satellites.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Syntax Sorcery Satellite Launcher (tmux sessions)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+User=ssadmin
+Group=ssadmin
+Environment=SATELLITE_BASE_DIR=/home/ssadmin/repos
+ExecStart=/home/ssadmin/scripts/azure/start-satellites.sh
+ExecStop=/usr/bin/tmux kill-server
+RemainAfterExit=yes
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/azure/start-satellites.sh
+++ b/scripts/azure/start-satellites.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# start-satellites.sh — Launch tmux sessions for all 5 downstream satellite repos
+# Idempotent: skips sessions that already exist
+set -euo pipefail
+
+REPOS=(flora ComeRosquillas pixel-bounce ffs-squad-monitor FirstFrameStudios)
+OWNER="jperezdelreal"
+BASE_DIR="${SATELLITE_BASE_DIR:-$HOME/repos}"
+DRY_RUN=false
+
+usage() {
+  echo "Usage: $0 [--dry-run] [--base-dir DIR]"
+  echo "  --dry-run    Validate config without launching tmux sessions"
+  echo "  --base-dir   Base directory containing repo clones (default: ~/repos)"
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)  DRY_RUN=true; shift ;;
+    --base-dir) BASE_DIR="$2"; shift 2 ;;
+    --help|-h)  usage ;;
+    *)          echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+log() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"; }
+
+errors=0
+
+for repo in "${REPOS[@]}"; do
+  repo_dir="$BASE_DIR/$repo"
+
+  if [[ ! -d "$repo_dir" ]]; then
+    log "ERROR: repo directory not found: $repo_dir"
+    errors=$((errors + 1))
+    continue
+  fi
+
+  if ! command -v copilot &>/dev/null; then
+    log "ERROR: 'copilot' CLI not found in PATH"
+    exit 1
+  fi
+
+  if $DRY_RUN; then
+    log "DRY-RUN: would launch tmux session 'sat-$repo' in $repo_dir"
+    continue
+  fi
+
+  session_name="sat-$repo"
+
+  if tmux has-session -t "$session_name" 2>/dev/null; then
+    log "SKIP: session '$session_name' already exists"
+    continue
+  fi
+
+  log "LAUNCH: creating tmux session '$session_name'"
+  tmux new-session -d -s "$session_name" -c "$repo_dir"
+  tmux send-keys -t "$session_name" "copilot" Enter
+  sleep 2
+  tmux send-keys -t "$session_name" "Ralph, go" Enter
+
+  log "OK: session '$session_name' started"
+done
+
+if $DRY_RUN; then
+  if [[ $errors -eq 0 ]]; then
+    log "DRY-RUN PASSED: all ${#REPOS[@]} repos validated"
+  else
+    log "DRY-RUN FAILED: $errors error(s) found"
+    exit 1
+  fi
+else
+  running=$(tmux list-sessions 2>/dev/null | grep -c '^sat-' || true)
+  log "DONE: $running satellite session(s) running"
+fi


### PR DESCRIPTION
## Summary

Adds scripts to provision and manage satellite Copilot CLI sessions on an Azure B2s v2 VM (Ubuntu 24.04, West Europe).

### Files
- `scripts/azure/start-satellites.sh` — Launch tmux sessions for all 5 downstream repos
- `scripts/azure/reset-satellite.sh` — Kill and restart a single satellite by repo name
- `scripts/azure/provision-vm.sh` — Azure CLI commands to provision B2s v2 VM
- `scripts/azure/satellites.service` — systemd unit for auto-start on boot
- `scripts/azure/README.md` — Setup, usage, and troubleshooting docs

### Key Features
- All scripts idempotent (safe to re-run)
- `--dry-run` flag validates config without launching
- tmux for terminal management, systemd for boot auto-start
- Budget: ~EUR 25-30/month

Closes #35