### PR TITLE
feat: add unified developer CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "check:constellation": "node scripts/constellation-health.js",
     "dashboard:ralph": "node scripts/parse-ralph-logs.js",
     "review:gate": "node scripts/review-gate.js",
-    "dedup:check": "node scripts/dedup-guard.js"
+    "dedup:check": "node scripts/dedup-guard.js",
+    "squad": "node scripts/squad-cli.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/__tests__/squad-cli.test.js
+++ b/scripts/__tests__/squad-cli.test.js
@@ -1,0 +1,219 @@
+/**
+ * Tests for scripts/squad-cli.js
+ *
+ * Uses vitest globals mode (vi, describe, it, expect, beforeEach, afterEach are global).
+ */
+
+const {
+  COMMANDS,
+  HELP_TEXT,
+  parseCliArgs,
+  cmdStatus,
+  cmdHelp,
+  route,
+  main,
+} = require('../squad-cli');
+
+// ---------------------------------------------------------------------------
+// parseCliArgs
+// ---------------------------------------------------------------------------
+
+describe('parseCliArgs', () => {
+  it('parses a bare command', () => {
+    const result = parseCliArgs(['node', 'squad-cli.js', 'status']);
+    expect(result.command).toBe('status');
+    expect(result.jsonMode).toBe(false);
+    expect(result.pr).toBeNull();
+  });
+
+  it('parses --json flag', () => {
+    const result = parseCliArgs(['node', 'squad-cli.js', 'health', '--json']);
+    expect(result.command).toBe('health');
+    expect(result.jsonMode).toBe(true);
+  });
+
+  it('parses --pr number for review', () => {
+    const result = parseCliArgs(['node', 'squad-cli.js', 'review', '--pr', '42']);
+    expect(result.command).toBe('review');
+    expect(result.pr).toBe(42);
+  });
+
+  it('returns null command when no args', () => {
+    const result = parseCliArgs(['node', 'squad-cli.js']);
+    expect(result.command).toBeNull();
+  });
+
+  it('returns null pr when --pr has no value', () => {
+    const result = parseCliArgs(['node', 'squad-cli.js', 'review', '--pr']);
+    expect(result.pr).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// COMMANDS constant
+// ---------------------------------------------------------------------------
+
+describe('COMMANDS', () => {
+  it('includes all expected commands', () => {
+    expect(COMMANDS).toEqual(['status', 'health', 'review', 'dedup', 'report', 'help']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cmdHelp
+// ---------------------------------------------------------------------------
+
+describe('cmdHelp', () => {
+  it('prints help text and returns 0', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const code = cmdHelp();
+    expect(code).toBe(0);
+    expect(spy).toHaveBeenCalledWith(HELP_TEXT);
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cmdStatus with injected exec
+// ---------------------------------------------------------------------------
+
+describe('cmdStatus', () => {
+  let logSpy;
+  let errorSpy;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('outputs JSON when --json flag is set', () => {
+    const mockExec = vi.fn((cmd) => {
+      if (cmd.includes('issue list')) {
+        return JSON.stringify([{ number: 1, title: 'Test issue', labels: [], assignees: [] }]);
+      }
+      if (cmd.includes('pr list')) {
+        return JSON.stringify([{ number: 10, title: 'Test PR', isDraft: false }]);
+      }
+      return '[]';
+    });
+
+    const code = cmdStatus(true, mockExec);
+    expect(code).toBe(0);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output.issues).toHaveLength(1);
+    expect(output.prs).toHaveLength(1);
+  });
+
+  it('outputs human-readable format by default', () => {
+    const mockExec = vi.fn((cmd) => {
+      if (cmd.includes('issue list')) {
+        return JSON.stringify([{ number: 5, title: 'My Issue', labels: [{ name: 'squad' }], assignees: [] }]);
+      }
+      if (cmd.includes('pr list')) {
+        return JSON.stringify([]);
+      }
+      return '[]';
+    });
+
+    const code = cmdStatus(false, mockExec);
+    expect(code).toBe(0);
+    const allOutput = logSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(allOutput).toContain('#5');
+    expect(allOutput).toContain('My Issue');
+    expect(allOutput).toContain('Open Issues');
+  });
+
+  it('returns 1 on exec error', () => {
+    const mockExec = vi.fn(() => { throw new Error('gh not found'); });
+    const code = cmdStatus(false, mockExec);
+    expect(code).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// route — command routing
+// ---------------------------------------------------------------------------
+
+describe('route', () => {
+  let logSpy;
+  let errorSpy;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('shows help and returns 1 for no command', () => {
+    const code = route({ command: null, jsonMode: false, pr: null });
+    expect(code).toBe(1);
+    const allOutput = logSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(allOutput).toContain('Squad CLI');
+  });
+
+  it('shows help and returns 1 for unknown command', () => {
+    const code = route({ command: 'foobar', jsonMode: false, pr: null });
+    expect(code).toBe(1);
+    const errorOutput = errorSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(errorOutput).toContain('unknown command');
+    expect(errorOutput).toContain('foobar');
+  });
+
+  it('routes help command successfully', () => {
+    const code = route({ command: 'help', jsonMode: false, pr: null });
+    expect(code).toBe(0);
+    const allOutput = logSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(allOutput).toContain('Squad CLI');
+  });
+
+  it('returns 1 for review without --pr', () => {
+    const code = route({ command: 'review', jsonMode: false, pr: null });
+    expect(code).toBe(1);
+    const errorOutput = errorSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(errorOutput).toContain('--pr');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// main — end-to-end argument wiring
+// ---------------------------------------------------------------------------
+
+describe('main', () => {
+  let logSpy;
+  let errorSpy;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('shows help and returns 1 with no args', () => {
+    const code = main(['node', 'squad-cli.js']);
+    expect(code).toBe(1);
+  });
+
+  it('routes help command from argv', () => {
+    const code = main(['node', 'squad-cli.js', 'help']);
+    expect(code).toBe(0);
+  });
+
+  it('returns 1 for unknown command from argv', () => {
+    const code = main(['node', 'squad-cli.js', 'nope']);
+    expect(code).toBe(1);
+  });
+});

--- a/scripts/squad-cli.js
+++ b/scripts/squad-cli.js
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Unified Developer CLI — single entry point for all squad operations.
+ *
+ * Usage:
+ *   node scripts/squad-cli.js <command> [options]
+ *   npm run squad -- <command> [options]
+ *
+ * Commands:
+ *   status   Show open issues and PR state
+ *   health   Run constellation health checks
+ *   review   Run review gate on a PR (requires --pr <number>)
+ *   dedup    Run dedup guard
+ *   report   Generate session report
+ *   help     Show this help message
+ *
+ * Flags:
+ *   --json   Machine-readable JSON output (where supported)
+ */
+
+const { execSync, spawnSync } = require('child_process');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const COMMANDS = ['status', 'health', 'review', 'dedup', 'report', 'help'];
+
+const HELP_TEXT = `
+Squad CLI — Unified developer CLI for all squad operations
+
+Usage:
+  npm run squad -- <command> [options]
+
+Commands:
+  status              Show open issues + PR state
+  health              Run constellation health checks
+  review --pr <num>   Run review gate on a PR
+  dedup               Run dedup guard
+  report              Generate session report
+  help                Show this help message
+
+Flags:
+  --json              Machine-readable JSON output (where supported)
+
+Examples:
+  npm run squad -- status
+  npm run squad -- health --json
+  npm run squad -- review --pr 42
+`.trim();
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+function parseCliArgs(argv) {
+  const args = argv.slice(2);
+  const command = args[0] || null;
+  const flags = args.slice(1);
+  const jsonMode = flags.includes('--json');
+
+  let pr = null;
+  const prIdx = flags.indexOf('--pr');
+  if (prIdx !== -1 && flags[prIdx + 1]) {
+    pr = parseInt(flags[prIdx + 1], 10);
+  }
+
+  return { command, flags, jsonMode, pr };
+}
+
+// ---------------------------------------------------------------------------
+// Command: status
+// ---------------------------------------------------------------------------
+
+function cmdStatus(jsonMode, execFn) {
+  const exec = execFn || execSync;
+  try {
+    const issuesRaw = exec('gh issue list --state open --json number,title,labels,assignees --limit 20', {
+      encoding: 'utf8',
+      timeout: 30_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const issues = JSON.parse(issuesRaw);
+
+    let prs = [];
+    try {
+      const prsRaw = exec('gh pr list --state open --json number,title,isDraft,statusCheckRollup --limit 20', {
+        encoding: 'utf8',
+        timeout: 30_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      prs = JSON.parse(prsRaw);
+    } catch {
+      // PRs may fail if no PRs exist; non-fatal
+    }
+
+    const result = { issues, prs };
+
+    if (jsonMode) {
+      console.log(JSON.stringify(result, null, 2));
+      return 0;
+    }
+
+    console.log('');
+    console.log('=== Open Issues ===');
+    if (issues.length === 0) {
+      console.log('  No open issues.');
+    } else {
+      for (const issue of issues) {
+        const labels = (issue.labels || []).map(l => l.name).join(', ');
+        const assignees = (issue.assignees || []).map(a => a.login).join(', ');
+        console.log(`  #${issue.number}  ${issue.title}`);
+        if (labels) console.log(`         Labels: ${labels}`);
+        if (assignees) console.log(`         Assignees: ${assignees}`);
+      }
+    }
+
+    console.log('');
+    console.log('=== Open PRs ===');
+    if (prs.length === 0) {
+      console.log('  No open PRs.');
+    } else {
+      for (const pr of prs) {
+        const draft = pr.isDraft ? ' [DRAFT]' : '';
+        console.log(`  #${pr.number}  ${pr.title}${draft}`);
+      }
+    }
+    console.log('');
+
+    return 0;
+  } catch (err) {
+    console.error(`Status error: ${err.message}`);
+    return 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command: health
+// ---------------------------------------------------------------------------
+
+function cmdHealth(jsonMode) {
+  const scriptPath = path.resolve(__dirname, 'constellation-health.js');
+  const args = jsonMode ? ['--json'] : [];
+  const result = spawnSync(process.execPath, [scriptPath, ...args], {
+    stdio: 'inherit',
+    timeout: 120_000,
+  });
+  return result.status || 0;
+}
+
+// ---------------------------------------------------------------------------
+// Command: review
+// ---------------------------------------------------------------------------
+
+function cmdReview(pr, jsonMode) {
+  if (!pr || isNaN(pr)) {
+    console.error('Error: review command requires --pr <number>');
+    console.error('Usage: npm run squad -- review --pr 42');
+    return 1;
+  }
+
+  const scriptPath = path.resolve(__dirname, 'review-gate.js');
+  const result = spawnSync(process.execPath, [scriptPath, '--pr', String(pr)], {
+    stdio: 'inherit',
+    timeout: 60_000,
+  });
+  return result.status || 0;
+}
+
+// ---------------------------------------------------------------------------
+// Command: dedup
+// ---------------------------------------------------------------------------
+
+function cmdDedup(jsonMode) {
+  const scriptPath = path.resolve(__dirname, 'dedup-guard.js');
+  const result = spawnSync(process.execPath, [scriptPath], {
+    stdio: 'inherit',
+    timeout: 30_000,
+  });
+  return result.status || 0;
+}
+
+// ---------------------------------------------------------------------------
+// Command: report
+// ---------------------------------------------------------------------------
+
+function cmdReport(jsonMode) {
+  const scriptPath = path.resolve(__dirname, 'session-report.js');
+  try {
+    require.resolve(scriptPath);
+  } catch {
+    console.error('Error: session-report.js not found.');
+    console.error('The report command will be available once scripts/session-report.js is created.');
+    return 1;
+  }
+
+  const args = jsonMode ? ['--json'] : [];
+  const result = spawnSync(process.execPath, [scriptPath, ...args], {
+    stdio: 'inherit',
+    timeout: 60_000,
+  });
+  return result.status || 0;
+}
+
+// ---------------------------------------------------------------------------
+// Command: help
+// ---------------------------------------------------------------------------
+
+function cmdHelp() {
+  console.log(HELP_TEXT);
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+function route(parsed) {
+  const { command, jsonMode, pr } = parsed;
+
+  if (!command) {
+    console.log(HELP_TEXT);
+    console.log('');
+    console.error('Error: no command specified.');
+    return 1;
+  }
+
+  if (!COMMANDS.includes(command)) {
+    console.log(HELP_TEXT);
+    console.log('');
+    console.error(`Error: unknown command "${command}".`);
+    return 1;
+  }
+
+  switch (command) {
+    case 'status':
+      return cmdStatus(jsonMode);
+    case 'health':
+      return cmdHealth(jsonMode);
+    case 'review':
+      return cmdReview(pr, jsonMode);
+    case 'dedup':
+      return cmdDedup(jsonMode);
+    case 'report':
+      return cmdReport(jsonMode);
+    case 'help':
+      return cmdHelp();
+    default:
+      return 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(argv) {
+  const parsed = parseCliArgs(argv || process.argv);
+  const exitCode = route(parsed);
+  return exitCode;
+}
+
+if (require.main === module) {
+  const code = main();
+  process.exit(code);
+}
+
+module.exports = {
+  COMMANDS,
+  HELP_TEXT,
+  parseCliArgs,
+  cmdStatus,
+  cmdHealth,
+  cmdReview,
+  cmdDedup,
+  cmdReport,
+  cmdHelp,
+  route,
+  main,
+};


### PR DESCRIPTION
## Summary

Single entry point (\\
pm run squad -- <command>\\) for all squad operations.

## Commands

| Command | Description | Wraps |
|---------|-------------|-------|
| \\status\\ | Open issues + PR state | gh CLI |
| \\health\\ | Constellation health checks | constellation-health.js |
| \\eview --pr <num>\\ | Review gate on a PR | review-gate.js |
| \\dedup\\ | Dedup guard | dedup-guard.js |
| \\eport\\ | Session report (graceful if missing) | session-report.js |
| \\help\\ | Show usage | — |

## Features

- \\--json\\ flag for machine-readable output (where supported)
- No args → shows usage + exits 1
- Unknown commands → help + exit 1
- No new dependencies — wraps existing scripts
- 17 unit tests covering routing, parsing, help, errors, JSON flag

Closes #49