### PR TITLE
feat: add constellation status page

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Syntax Sorcery is an autonomous software development company. AI agents design, 
 
 **Current status:** Phase 3 complete · 6 repos in constellation · 168 tests · 6 PRs merged autonomously
 
+📡 **[Constellation Status](https://jperezdelreal.github.io/Syntax-Sorcery/status/)** — Live health dashboard for all 6 repos
+
 ---
 
 ## How It Works

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -50,7 +50,7 @@ const constellation = await getConstellationWithStats();
           </span>
         </div>
 
-        <div class="flex justify-center gap-4">
+        <div class="flex flex-wrap justify-center gap-4">
           <a
             href="https://github.com/jperezdelreal/Syntax-Sorcery"
             target="_blank"
@@ -59,6 +59,12 @@ const constellation = await getConstellationWithStats();
           >
             <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
             View Source
+          </a>
+          <a
+            href="/Syntax-Sorcery/status/"
+            class="inline-flex items-center gap-2 px-6 py-3 bg-matrix-green/10 text-matrix-green border border-matrix-green/30 rounded-lg font-mono text-sm hover:bg-matrix-green/20 hover:border-matrix-green/50 transition-all duration-300"
+          >
+            📡 Status
           </a>
           <a
             href="#how-it-works"

--- a/site/src/pages/status.astro
+++ b/site/src/pages/status.astro
@@ -1,0 +1,174 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { getConstellationWithStats } from '../utils/data';
+
+const constellation = await getConstellationWithStats();
+const now = Date.now();
+
+function getHealth(lastPush?: string): { label: string; color: string; dot: string } {
+  if (!lastPush) return { label: 'Unknown', color: 'text-gray-500', dot: 'bg-gray-500' };
+  const days = Math.floor((now - new Date(lastPush).getTime()) / (1000 * 60 * 60 * 24));
+  if (days <= 7) return { label: 'Healthy', color: 'text-matrix-green', dot: 'bg-matrix-green' };
+  if (days <= 30) return { label: 'Idle', color: 'text-yellow-400', dot: 'bg-yellow-400' };
+  return { label: 'Stale', color: 'text-red-400', dot: 'bg-red-400' };
+}
+
+function daysSince(lastPush?: string): string {
+  if (!lastPush) return '—';
+  const days = Math.floor((now - new Date(lastPush).getTime()) / (1000 * 60 * 60 * 24));
+  if (days === 0) return 'Today';
+  if (days === 1) return '1 day ago';
+  return `${days} days ago`;
+}
+
+const healthyCount = constellation.filter(r => {
+  if (!r.lastPush) return false;
+  return (now - new Date(r.lastPush).getTime()) / (1000 * 60 * 60 * 24) <= 7;
+}).length;
+
+const totalIssues = constellation.reduce((sum, r) => sum + (r.openIssues ?? 0), 0);
+
+const ciWorkflows: Record<string, string> = {
+  'Syntax-Sorcery': 'ci.yml',
+  'FirstFrameStudios': 'deploy.yml',
+  'flora': 'deploy.yml',
+  'ComeRosquillas': 'deploy.yml',
+  'pixel-bounce': 'deploy-pages.yml',
+  'ffs-squad-monitor': 'deploy.yml',
+};
+---
+
+<Layout title="Constellation Status — Syntax Sorcery" description="Live health status of all 6 constellation repositories.">
+  <main class="container mx-auto px-4 max-w-6xl py-12">
+
+    <!-- Header -->
+    <div class="text-center mb-12 scroll-fade">
+      <a href="/Syntax-Sorcery/" class="inline-block text-matrix-green/60 hover:text-matrix-green font-mono text-sm mb-6 transition-colors">
+        ← Back to Home
+      </a>
+      <h1 class="text-4xl md:text-5xl font-extrabold mb-4 tracking-tight">
+        <span class="bg-gradient-to-r from-matrix-green via-emerald-400 to-matrix-green bg-clip-text text-transparent">
+          Constellation Status
+        </span>
+      </h1>
+      <p class="text-gray-500 max-w-xl mx-auto font-mono text-sm">
+        Live health of all {constellation.length} repositories — updated at build time.
+      </p>
+    </div>
+
+    <!-- Summary Bar -->
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-12 scroll-fade">
+      <div class="p-4 glass rounded-xl text-center">
+        <div class="text-3xl font-bold text-matrix-green font-mono text-glow">{constellation.length}</div>
+        <div class="text-gray-500 text-xs font-mono mt-1">Total Repos</div>
+      </div>
+      <div class="p-4 glass rounded-xl text-center">
+        <div class="text-3xl font-bold text-matrix-green font-mono text-glow">{healthyCount}</div>
+        <div class="text-gray-500 text-xs font-mono mt-1">Healthy</div>
+      </div>
+      <div class="p-4 glass rounded-xl text-center">
+        <div class="text-3xl font-bold text-matrix-green font-mono text-glow">168+</div>
+        <div class="text-gray-500 text-xs font-mono mt-1">Total Tests</div>
+      </div>
+      <div class="p-4 glass rounded-xl text-center">
+        <div class="text-3xl font-bold text-matrix-green font-mono text-glow">P5</div>
+        <div class="text-gray-500 text-xs font-mono mt-1">Current Phase</div>
+      </div>
+    </div>
+
+    <!-- Repo Cards -->
+    <div class="grid md:grid-cols-2 gap-6 mb-12">
+      {constellation.map((repo, i) => {
+        const health = getHealth(repo.lastPush);
+        const workflow = ciWorkflows[repo.name] || 'ci.yml';
+        const badgeUrl = `https://github.com/${repo.fullName}/actions/workflows/${workflow}/badge.svg`;
+        return (
+          <div class="scroll-fade p-5 glass rounded-xl card-hover" style={`animation-delay: ${i * 80}ms`}>
+            <div class="flex items-start justify-between gap-3 mb-3">
+              <div class="flex items-center gap-2 min-w-0">
+                <span class:list={['w-2.5 h-2.5 rounded-full shrink-0', health.dot]} aria-label={health.label} />
+                <a
+                  href={repo.url}
+                  target="_blank"
+                  rel="noopener"
+                  class="font-mono text-base font-bold hover:text-matrix-green transition-colors truncate"
+                >
+                  {repo.name}
+                </a>
+              </div>
+              <span class:list={['text-xs font-mono whitespace-nowrap', health.color]}>
+                {health.label}
+              </span>
+            </div>
+
+            <p class="text-gray-500 text-sm mb-3">{repo.description}</p>
+
+            <!-- CI Badge -->
+            <div class="mb-3">
+              <a href={`${repo.url}/actions`} target="_blank" rel="noopener">
+                <img
+                  src={badgeUrl}
+                  alt={`CI status for ${repo.name}`}
+                  class="h-5"
+                  loading="lazy"
+                />
+              </a>
+            </div>
+
+            <!-- Stats Row -->
+            <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs font-mono text-gray-500">
+              {repo.openIssues !== undefined && (
+                <span class="flex items-center gap-1">
+                  <span class="text-matrix-green/60">📋</span>
+                  {repo.openIssues} open issue{repo.openIssues !== 1 ? 's' : ''}
+                </span>
+              )}
+              {repo.lastPush && (
+                <span class="flex items-center gap-1">
+                  <span class="text-matrix-green/60">🕐</span>
+                  {daysSince(repo.lastPush)}
+                </span>
+              )}
+              {repo.stars !== undefined && (
+                <span class="flex items-center gap-1">
+                  <span class="text-matrix-green/60">⭐</span>
+                  {repo.stars}
+                </span>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+
+    <!-- Legend -->
+    <div class="scroll-fade glass rounded-xl p-5 mb-12">
+      <h2 class="text-sm font-mono text-matrix-green/80 mb-3">Health Indicators</h2>
+      <div class="flex flex-wrap gap-6 text-xs text-gray-400 font-mono">
+        <span class="flex items-center gap-2">
+          <span class="w-2.5 h-2.5 rounded-full bg-matrix-green inline-block"></span>
+          Green — Active within 7 days
+        </span>
+        <span class="flex items-center gap-2">
+          <span class="w-2.5 h-2.5 rounded-full bg-yellow-400 inline-block"></span>
+          Yellow — Active 7–30 days ago
+        </span>
+        <span class="flex items-center gap-2">
+          <span class="w-2.5 h-2.5 rounded-full bg-red-400 inline-block"></span>
+          Red — Inactive 30+ days
+        </span>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="scroll-fade text-center pt-8 pb-4 border-t border-gray-800/50">
+      <p class="text-gray-600 text-xs font-mono">
+        <span class="text-matrix-green/40">⟨SS⟩</span> Constellation Status — Syntax Sorcery
+      </p>
+      <p class="text-gray-700 text-xs mt-1 font-mono">
+        Data fetched at build time via GitHub API
+      </p>
+    </footer>
+
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary

Adds a public /status page to the Astro landing site showing live health of all 6 constellation repositories.

### What's included

- **New page** \site/src/pages/status.astro\ — Constellation status dashboard
- **Nav link** added to \index.astro\ hero section (📡 Status button)
- **README link** to the live status page

### Per-repo display
- Name + link to GitHub repo
- Description
- CI badge (linked to Actions)
- Last activity (days ago)
- Open issue count
- Health indicator: 🟢 green (≤7 days), 🟡 yellow (7–30 days), 🔴 red (30+ days)

### Summary bar
- Total repos (6)
- Healthy count
- Total tests (168+)
- Current phase (P5)

### Design
- Matrix theme consistent with landing page (dark bg, #00ff41 green accents)
- Mobile responsive grid (1 col → 2 col)
- prefers-reduced-motion respected via existing Layout scroll-fade system
- Zero external dependencies — reuses \getConstellationWithStats()\ from \data.ts\

### Verification
- ✅ Astro build passes (2 pages, 8.45s)
- ✅ 218 tests pass

Closes #50