### PR TITLE
feat: add autonomous performance metrics engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "review:gate": "node scripts/review-gate.js",
     "dedup:check": "node scripts/dedup-guard.js",
     "report:session": "node scripts/session-report.js",
+    "metrics": "node scripts/metrics-engine.js",
     "squad": "node scripts/squad-cli.js"
   },
   "repository": {

--- a/scripts/__tests__/metrics-engine.test.js
+++ b/scripts/__tests__/metrics-engine.test.js
@@ -1,0 +1,729 @@
+/**
+ * Tests for scripts/metrics-engine.js
+ *
+ * Mocks execGh via the injected deps parameter to avoid real gh CLI calls.
+ * Uses vitest globals mode (vi, describe, it, expect, beforeEach are global).
+ */
+
+const {
+  parseArgs,
+  getDefaultDateRange,
+  fetchClosedIssues,
+  fetchAllIssues,
+  fetchMergedPRs,
+  fetchClosedPRs,
+  computeVelocity,
+  computeCycleTime,
+  computeQualityRate,
+  computeTestGrowth,
+  computeThroughput,
+  computeStreak,
+  computeTrend,
+  trendIndicator,
+  compareWithPrevious,
+  getSnapshotPath,
+  loadPreviousSnapshot,
+  formatTable,
+  run,
+} = require('../metrics-engine');
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe('parseArgs', () => {
+  it('parses --since and --until flags', () => {
+    const result = parseArgs(['node', 'metrics-engine.js', '--since', '2026-03-01', '--until', '2026-03-20']);
+    expect(result.since).toBe('2026-03-01');
+    expect(result.until).toBe('2026-03-20');
+    expect(result.json).toBe(false);
+    expect(result.save).toBe(false);
+  });
+
+  it('parses --json flag', () => {
+    const result = parseArgs(['node', 'metrics-engine.js', '--json']);
+    expect(result.json).toBe(true);
+  });
+
+  it('parses --save flag', () => {
+    const result = parseArgs(['node', 'metrics-engine.js', '--save']);
+    expect(result.save).toBe(true);
+  });
+
+  it('parses all flags together', () => {
+    const result = parseArgs(['node', 'metrics-engine.js', '--since', '2026-03-01', '--until', '2026-03-20', '--json', '--save']);
+    expect(result.since).toBe('2026-03-01');
+    expect(result.until).toBe('2026-03-20');
+    expect(result.json).toBe(true);
+    expect(result.save).toBe(true);
+  });
+
+  it('returns defaults when no flags provided', () => {
+    const result = parseArgs(['node', 'metrics-engine.js']);
+    expect(result.since).toBeNull();
+    expect(result.until).toBeNull();
+    expect(result.json).toBe(false);
+    expect(result.save).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDefaultDateRange
+// ---------------------------------------------------------------------------
+
+describe('getDefaultDateRange', () => {
+  it('returns since and until as ISO strings', () => {
+    const range = getDefaultDateRange();
+    expect(range.since).toBeTruthy();
+    expect(range.until).toBeTruthy();
+    expect(new Date(range.since).getTime()).toBeLessThan(new Date(range.until).getTime());
+  });
+
+  it('covers approximately 7 days', () => {
+    const range = getDefaultDateRange();
+    const diff = new Date(range.until).getTime() - new Date(range.since).getTime();
+    const days = diff / (1000 * 60 * 60 * 24);
+    expect(days).toBeCloseTo(7, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fetch functions (DI-mocked gh CLI)
+// ---------------------------------------------------------------------------
+
+describe('fetchClosedIssues', () => {
+  it('returns parsed issues from gh CLI output', () => {
+    const mockExec = vi.fn().mockReturnValue(
+      JSON.stringify([{ number: 48, title: 'Issue', closedAt: '2026-03-19T14:00:00Z' }])
+    );
+    const result = fetchClosedIssues('2026-03-19', mockExec);
+    expect(result).toEqual([{ number: 48, title: 'Issue', closedAt: '2026-03-19T14:00:00Z' }]);
+    expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('gh issue list'));
+    expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('--state closed'));
+  });
+
+  it('propagates exec errors', () => {
+    const mockExec = vi.fn().mockImplementation(() => { throw new Error('gh not found'); });
+    expect(() => fetchClosedIssues('2026-03-19', mockExec)).toThrow('gh not found');
+  });
+});
+
+describe('fetchAllIssues', () => {
+  it('returns parsed issues from gh CLI output', () => {
+    const mockExec = vi.fn().mockReturnValue(
+      JSON.stringify([{ number: 1, title: 'Issue', state: 'OPEN' }])
+    );
+    const result = fetchAllIssues('2026-03-19', mockExec);
+    expect(result).toHaveLength(1);
+    expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('--state all'));
+  });
+});
+
+describe('fetchMergedPRs', () => {
+  it('returns parsed PRs from gh CLI output', () => {
+    const mockExec = vi.fn().mockReturnValue(
+      JSON.stringify([{ number: 50, title: 'feat: thing', mergedAt: '2026-03-19T12:00:00Z' }])
+    );
+    const result = fetchMergedPRs('2026-03-19', mockExec);
+    expect(result).toEqual([{ number: 50, title: 'feat: thing', mergedAt: '2026-03-19T12:00:00Z' }]);
+    expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('--state merged'));
+  });
+});
+
+describe('fetchClosedPRs', () => {
+  it('returns parsed PRs from gh CLI output', () => {
+    const mockExec = vi.fn().mockReturnValue(
+      JSON.stringify([{ number: 45, title: 'bad: pr', mergedAt: null, closedAt: '2026-03-19T10:00:00Z' }])
+    );
+    const result = fetchClosedPRs('2026-03-19', mockExec);
+    expect(result).toHaveLength(1);
+    expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('--state closed'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeVelocity
+// ---------------------------------------------------------------------------
+
+describe('computeVelocity', () => {
+  it('computes issues closed per day', () => {
+    const issues = [{ number: 1 }, { number: 2 }, { number: 3 }];
+    const result = computeVelocity(issues, '2026-03-18T00:00:00Z', '2026-03-20T00:00:00Z');
+    expect(result.value).toBe(1.5);
+    expect(result.unit).toBe('issues/day');
+    expect(result.raw).toBe(3);
+  });
+
+  it('handles zero issues', () => {
+    const result = computeVelocity([], '2026-03-18T00:00:00Z', '2026-03-20T00:00:00Z');
+    expect(result.value).toBe(0);
+    expect(result.raw).toBe(0);
+  });
+
+  it('uses minimum 1 day to avoid division by zero', () => {
+    const issues = [{ number: 1 }];
+    const result = computeVelocity(issues, '2026-03-19T00:00:00Z', '2026-03-19T00:00:00Z');
+    expect(result.value).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeCycleTime
+// ---------------------------------------------------------------------------
+
+describe('computeCycleTime', () => {
+  it('computes average hours from issue creation to merge', () => {
+    const mergedPRs = [
+      {
+        number: 10,
+        mergedAt: '2026-03-19T12:00:00Z',
+        closingIssuesReferences: [
+          { number: 5, createdAt: '2026-03-19T00:00:00Z' },
+        ],
+      },
+    ];
+    const result = computeCycleTime(mergedPRs);
+    expect(result.value).toBe(12);
+    expect(result.unit).toBe('hours');
+    expect(result.raw).toBe(1);
+  });
+
+  it('averages multiple cycle times', () => {
+    const mergedPRs = [
+      {
+        number: 10,
+        mergedAt: '2026-03-19T12:00:00Z',
+        closingIssuesReferences: [
+          { number: 5, createdAt: '2026-03-19T00:00:00Z' },
+        ],
+      },
+      {
+        number: 11,
+        mergedAt: '2026-03-20T00:00:00Z',
+        closingIssuesReferences: [
+          { number: 6, createdAt: '2026-03-19T00:00:00Z' },
+        ],
+      },
+    ];
+    const result = computeCycleTime(mergedPRs);
+    expect(result.value).toBe(18); // (12 + 24) / 2
+    expect(result.raw).toBe(2);
+  });
+
+  it('returns null when no PRs have linked issues', () => {
+    const mergedPRs = [
+      { number: 10, mergedAt: '2026-03-19T12:00:00Z', closingIssuesReferences: [] },
+    ];
+    const result = computeCycleTime(mergedPRs);
+    expect(result.value).toBeNull();
+    expect(result.raw).toBe(0);
+  });
+
+  it('returns null for empty PRs array', () => {
+    const result = computeCycleTime([]);
+    expect(result.value).toBeNull();
+  });
+
+  it('skips refs without createdAt', () => {
+    const mergedPRs = [
+      {
+        number: 10,
+        mergedAt: '2026-03-19T12:00:00Z',
+        closingIssuesReferences: [{ number: 5 }],
+      },
+    ];
+    const result = computeCycleTime(mergedPRs);
+    expect(result.value).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeQualityRate
+// ---------------------------------------------------------------------------
+
+describe('computeQualityRate', () => {
+  it('computes merge percentage', () => {
+    const merged = [{ number: 10 }, { number: 11 }];
+    const closed = [
+      { number: 10, mergedAt: '2026-03-19T12:00:00Z' },
+      { number: 11, mergedAt: '2026-03-19T13:00:00Z' },
+      { number: 12, mergedAt: null, closedAt: '2026-03-19T14:00:00Z' },
+    ];
+    const result = computeQualityRate(merged, closed);
+    expect(result.value).toBeCloseTo(66.67, 1);
+    expect(result.unit).toBe('%');
+    expect(result.merged).toBe(2);
+    expect(result.rejected).toBe(1);
+    expect(result.total).toBe(3);
+  });
+
+  it('returns 100% when all merged', () => {
+    const merged = [{ number: 10 }];
+    const closed = [{ number: 10, mergedAt: '2026-03-19T12:00:00Z' }];
+    const result = computeQualityRate(merged, closed);
+    expect(result.value).toBe(100);
+  });
+
+  it('returns null when no PRs', () => {
+    const result = computeQualityRate([], []);
+    expect(result.value).toBeNull();
+    expect(result.total).toBe(0);
+  });
+
+  it('returns 0% when all rejected', () => {
+    const merged = [];
+    const closed = [{ number: 10, mergedAt: null }];
+    const result = computeQualityRate(merged, closed);
+    expect(result.value).toBe(0);
+    expect(result.rejected).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeTestGrowth
+// ---------------------------------------------------------------------------
+
+describe('computeTestGrowth', () => {
+  it('returns test count', () => {
+    const result = computeTestGrowth(218);
+    expect(result.value).toBe(218);
+    expect(result.unit).toBe('tests');
+  });
+
+  it('handles null test count', () => {
+    const result = computeTestGrowth(null);
+    expect(result.value).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeThroughput
+// ---------------------------------------------------------------------------
+
+describe('computeThroughput', () => {
+  it('computes PRs merged per day', () => {
+    const prs = [{ number: 10 }, { number: 11 }];
+    const result = computeThroughput(prs, '2026-03-18T00:00:00Z', '2026-03-20T00:00:00Z');
+    expect(result.value).toBe(1);
+    expect(result.unit).toBe('PRs/day');
+    expect(result.raw).toBe(2);
+  });
+
+  it('handles zero PRs', () => {
+    const result = computeThroughput([], '2026-03-18T00:00:00Z', '2026-03-20T00:00:00Z');
+    expect(result.value).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeStreak
+// ---------------------------------------------------------------------------
+
+describe('computeStreak', () => {
+  it('computes consecutive days with merged PRs', () => {
+    const prs = [
+      { number: 1, mergedAt: '2026-03-19T10:00:00Z' },
+      { number: 2, mergedAt: '2026-03-18T14:00:00Z' },
+      { number: 3, mergedAt: '2026-03-17T08:00:00Z' },
+    ];
+    const result = computeStreak(prs);
+    expect(result.value).toBe(3);
+    expect(result.unit).toBe('days');
+  });
+
+  it('returns 1 for single day', () => {
+    const prs = [{ number: 1, mergedAt: '2026-03-19T10:00:00Z' }];
+    const result = computeStreak(prs);
+    expect(result.value).toBe(1);
+  });
+
+  it('returns 0 for no PRs', () => {
+    const result = computeStreak([]);
+    expect(result.value).toBe(0);
+  });
+
+  it('breaks streak on gap', () => {
+    const prs = [
+      { number: 1, mergedAt: '2026-03-19T10:00:00Z' },
+      { number: 2, mergedAt: '2026-03-17T14:00:00Z' }, // gap on 03-18
+    ];
+    const result = computeStreak(prs);
+    expect(result.value).toBe(1);
+  });
+
+  it('counts multiple PRs on same day as 1', () => {
+    const prs = [
+      { number: 1, mergedAt: '2026-03-19T10:00:00Z' },
+      { number: 2, mergedAt: '2026-03-19T14:00:00Z' },
+      { number: 3, mergedAt: '2026-03-18T08:00:00Z' },
+    ];
+    const result = computeStreak(prs);
+    expect(result.value).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeTrend / trendIndicator
+// ---------------------------------------------------------------------------
+
+describe('computeTrend', () => {
+  it('returns UP when current > previous', () => {
+    expect(computeTrend(10, 5)).toBe('UP');
+  });
+
+  it('returns DOWN when current < previous', () => {
+    expect(computeTrend(3, 5)).toBe('DOWN');
+  });
+
+  it('returns FLAT when equal', () => {
+    expect(computeTrend(5, 5)).toBe('FLAT');
+  });
+
+  it('returns NEW when previous is null', () => {
+    expect(computeTrend(5, null)).toBe('NEW');
+  });
+
+  it('returns NEW when current is null', () => {
+    expect(computeTrend(null, 5)).toBe('NEW');
+  });
+});
+
+describe('trendIndicator', () => {
+  it('maps trend strings to symbols', () => {
+    expect(trendIndicator('UP')).toBe('▲');
+    expect(trendIndicator('DOWN')).toBe('▼');
+    expect(trendIndicator('FLAT')).toBe('→');
+    expect(trendIndicator('NEW')).toBe('★');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compareWithPrevious
+// ---------------------------------------------------------------------------
+
+describe('compareWithPrevious', () => {
+  it('returns all NEW when no previous snapshot', () => {
+    const metrics = {
+      velocity: { value: 2 },
+      cycleTime: { value: 12 },
+    };
+    const result = compareWithPrevious(metrics, null);
+    expect(result.velocity).toBe('NEW');
+    expect(result.cycleTime).toBe('NEW');
+  });
+
+  it('computes trends against previous snapshot', () => {
+    const metrics = {
+      velocity: { value: 3 },
+      cycleTime: { value: 8 },
+      throughput: { value: 2 },
+    };
+    const previous = {
+      metrics: {
+        velocity: { value: 2 },
+        cycleTime: { value: 12 },
+        throughput: { value: 2 },
+      },
+    };
+    const result = compareWithPrevious(metrics, previous);
+    expect(result.velocity).toBe('UP');
+    expect(result.cycleTime).toBe('DOWN');
+    expect(result.throughput).toBe('FLAT');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSnapshotPath
+// ---------------------------------------------------------------------------
+
+describe('getSnapshotPath', () => {
+  it('generates correct path from ISO date string', () => {
+    const result = getSnapshotPath('2026-03-20T12:00:00Z');
+    expect(result).toContain('2026-03-20.json');
+    expect(result).toContain('docs');
+    expect(result).toContain('metrics');
+  });
+
+  it('handles date-only string', () => {
+    const result = getSnapshotPath('2026-03-20');
+    expect(result).toContain('2026-03-20.json');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadPreviousSnapshot
+// ---------------------------------------------------------------------------
+
+describe('loadPreviousSnapshot', () => {
+  it('returns null when directory does not exist', () => {
+    const result = loadPreviousSnapshot('/nonexistent/path');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no JSON files exist', () => {
+    const origReaddirSync = require('fs').readdirSync;
+    vi.spyOn(require('fs'), 'readdirSync').mockReturnValue(['readme.txt']);
+    const result = loadPreviousSnapshot('/some/dir');
+    require('fs').readdirSync.mockRestore();
+    expect(result).toBeNull();
+  });
+
+  it('loads the most recent snapshot file', () => {
+    vi.spyOn(require('fs'), 'readdirSync').mockReturnValue([
+      '2026-03-18.json',
+      '2026-03-19.json',
+    ]);
+    const mockRead = vi.fn().mockReturnValue(JSON.stringify({
+      metrics: { velocity: { value: 2 } },
+    }));
+    const result = loadPreviousSnapshot('/some/dir', mockRead);
+    expect(result).toEqual({ metrics: { velocity: { value: 2 } } });
+    expect(mockRead).toHaveBeenCalledWith(expect.stringContaining('2026-03-19.json'));
+    require('fs').readdirSync.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatTable
+// ---------------------------------------------------------------------------
+
+describe('formatTable', () => {
+  it('formats metrics as a human-readable table', () => {
+    const metrics = {
+      velocity: { value: 2.5, unit: 'issues/day' },
+      cycleTime: { value: 8.5, unit: 'hours' },
+      qualityRate: { value: 100, unit: '%' },
+      testGrowth: { value: 218, unit: 'tests' },
+      throughput: { value: 1.5, unit: 'PRs/day' },
+      streak: { value: 3, unit: 'days' },
+    };
+    const trends = {
+      velocity: 'UP',
+      cycleTime: 'DOWN',
+      qualityRate: 'FLAT',
+      testGrowth: 'UP',
+      throughput: 'NEW',
+      streak: 'UP',
+    };
+    const table = formatTable(metrics, trends);
+    expect(table).toContain('Velocity');
+    expect(table).toContain('2.5');
+    expect(table).toContain('▲');
+    expect(table).toContain('▼');
+    expect(table).toContain('→');
+    expect(table).toContain('★');
+  });
+
+  it('shows N/A for null values', () => {
+    const metrics = {
+      cycleTime: { value: null, unit: 'hours' },
+    };
+    const trends = { cycleTime: 'NEW' };
+    const table = formatTable(metrics, trends);
+    expect(table).toContain('N/A');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run — integration with mocked deps
+// ---------------------------------------------------------------------------
+
+describe('run', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeMockDeps(options = {}) {
+    const closedIssues = options.closedIssues || [];
+    const allIssues = options.allIssues || [];
+    const mergedPRs = options.mergedPRs || [];
+    const closedPRs = options.closedPRs || [];
+    const written = {};
+
+    return {
+      execGh: (cmd) => {
+        if (cmd.includes('--state closed') && cmd.includes('gh issue list'))
+          return JSON.stringify(closedIssues);
+        if (cmd.includes('--state all') && cmd.includes('gh issue list'))
+          return JSON.stringify(allIssues);
+        if (cmd.includes('--state merged'))
+          return JSON.stringify(mergedPRs);
+        if (cmd.includes('--state closed') && cmd.includes('gh pr list'))
+          return JSON.stringify(closedPRs);
+        if (cmd.includes('vitest'))
+          throw new Error('no test runner');
+        throw new Error(`Unexpected command: ${cmd}`);
+      },
+      writeFile: (filePath, content) => {
+        written.path = filePath;
+        written.content = content;
+      },
+      readFile: null,
+      snapshotDir: '/nonexistent',
+      written,
+    };
+  }
+
+  it('returns exitCode 0 on success with JSON output', async () => {
+    const deps = makeMockDeps({
+      closedIssues: [{ number: 48, title: 'Report', closedAt: '2026-03-19T14:00:00Z' }],
+      mergedPRs: [{ number: 50, title: 'PR', mergedAt: '2026-03-19T12:00:00Z', closingIssuesReferences: [] }],
+    });
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await run(
+      ['node', 'metrics-engine.js', '--since', '2026-03-19T00:00:00Z', '--until', '2026-03-19T23:59:59Z', '--json'],
+      deps
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.snapshot).toBeDefined();
+    expect(result.snapshot.metrics.velocity.value).toBeGreaterThan(0);
+    consoleSpy.mockRestore();
+  });
+
+  it('returns exitCode 0 with human-readable output', async () => {
+    const deps = makeMockDeps({
+      closedIssues: [{ number: 1, title: 'Issue' }],
+      mergedPRs: [{ number: 10, mergedAt: '2026-03-19T12:00:00Z', closingIssuesReferences: [] }],
+    });
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await run(
+      ['node', 'metrics-engine.js', '--since', '2026-03-19T00:00:00Z', '--until', '2026-03-19T23:59:59Z'],
+      deps
+    );
+
+    expect(result.exitCode).toBe(0);
+    const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(allOutput).toContain('Autonomous Performance Metrics');
+    expect(allOutput).toContain('Velocity');
+    consoleSpy.mockRestore();
+  });
+
+  it('saves snapshot when --save is set', async () => {
+    const deps = makeMockDeps();
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await run(
+      ['node', 'metrics-engine.js', '--since', '2026-03-19T00:00:00Z', '--until', '2026-03-19T23:59:59Z', '--json', '--save'],
+      deps
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.written.path).toContain('2026-03-19.json');
+    expect(deps.written.content).toContain('"velocity"');
+    consoleSpy.mockRestore();
+  });
+
+  it('returns exitCode 1 when closed issues fetch fails', async () => {
+    const deps = {
+      execGh: () => { throw new Error('API timeout'); },
+      writeFile: () => {},
+      snapshotDir: '/nonexistent',
+    };
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await run(
+      ['node', 'metrics-engine.js', '--since', '2026-03-19T00:00:00Z', '--until', '2026-03-19T23:59:59Z'],
+      deps
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('failed to fetch closed issues'));
+    consoleSpy.mockRestore();
+  });
+
+  it('returns exitCode 1 when all issues fetch fails', async () => {
+    const deps = {
+      execGh: (cmd) => {
+        if (cmd.includes('--state closed') && cmd.includes('gh issue list')) return '[]';
+        throw new Error('API error');
+      },
+      writeFile: () => {},
+      snapshotDir: '/nonexistent',
+    };
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await run(
+      ['node', 'metrics-engine.js', '--since', '2026-03-19T00:00:00Z', '--until', '2026-03-19T23:59:59Z'],
+      deps
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('failed to fetch issues'));
+    consoleSpy.mockRestore();
+  });
+
+  it('returns exitCode 1 when merged PRs fetch fails', async () => {
+    const deps = {
+      execGh: (cmd) => {
+        if (cmd.includes('gh issue list')) return '[]';
+        throw new Error('PR API down');
+      },
+      writeFile: () => {},
+      snapshotDir: '/nonexistent',
+    };
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await run(
+      ['node', 'metrics-engine.js', '--since', '2026-03-19T00:00:00Z', '--until', '2026-03-19T23:59:59Z'],
+      deps
+    );
+
+    expect(result.exitCode).toBe(1);
+    consoleSpy.mockRestore();
+  });
+
+  it('returns exitCode 1 when save fails', async () => {
+    const deps = {
+      execGh: (cmd) => {
+        if (cmd.includes('gh issue list')) return '[]';
+        if (cmd.includes('gh pr list')) return '[]';
+        throw new Error('skip');
+      },
+      writeFile: () => { throw new Error('EACCES'); },
+      snapshotDir: '/nonexistent',
+    };
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await run(
+      ['node', 'metrics-engine.js', '--since', '2026-03-19T00:00:00Z', '--until', '2026-03-19T23:59:59Z', '--json', '--save'],
+      deps
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('failed to save snapshot'));
+    consoleSpy.mockRestore();
+  });
+
+  it('proceeds without test count when test runner fails', async () => {
+    const deps = makeMockDeps();
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await run(
+      ['node', 'metrics-engine.js', '--since', '2026-03-19T00:00:00Z', '--until', '2026-03-19T23:59:59Z', '--json'],
+      deps
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.snapshot.metrics.testGrowth.value).toBeNull();
+    consoleSpy.mockRestore();
+  });
+
+  it('includes trend comparison in snapshot', async () => {
+    const deps = makeMockDeps();
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await run(
+      ['node', 'metrics-engine.js', '--since', '2026-03-19T00:00:00Z', '--until', '2026-03-19T23:59:59Z', '--json'],
+      deps
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.snapshot.trends).toBeDefined();
+    expect(result.snapshot.trends.velocity).toBe('NEW');
+    consoleSpy.mockRestore();
+  });
+});

--- a/scripts/__tests__/squad-cli.test.js
+++ b/scripts/__tests__/squad-cli.test.js
@@ -55,7 +55,7 @@ describe('parseCliArgs', () => {
 
 describe('COMMANDS', () => {
   it('includes all expected commands', () => {
-    expect(COMMANDS).toEqual(['status', 'health', 'review', 'dedup', 'report', 'help']);
+    expect(COMMANDS).toEqual(['status', 'health', 'review', 'dedup', 'report', 'metrics', 'help']);
   });
 });
 

--- a/scripts/metrics-engine.js
+++ b/scripts/metrics-engine.js
@@ -1,0 +1,502 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Autonomous Performance Metrics Engine
+ *
+ * Aggregates GitHub data into KPIs for measuring autonomous development
+ * performance: velocity, cycle time, quality rate, test growth, throughput,
+ * and streak.
+ *
+ * Usage:
+ *   node scripts/metrics-engine.js
+ *   node scripts/metrics-engine.js --since 2026-03-01 --until 2026-03-20
+ *   node scripts/metrics-engine.js --json
+ *   node scripts/metrics-engine.js --save
+ *
+ * Flags:
+ *   --since   Start date (ISO 8601 or YYYY-MM-DD). Default: 7 days ago
+ *   --until   End date (ISO 8601 or YYYY-MM-DD). Default: now
+ *   --json    Output raw JSON instead of human-readable table
+ *   --save    Save snapshot to docs/metrics/YYYY-MM-DD.json
+ *
+ * Exit codes:
+ *   0 — success
+ *   1 — error
+ *
+ * Requires: gh CLI authenticated with repo scope.
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const result = { since: null, until: null, json: false, save: false };
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--since' && args[i + 1]) {
+      result.since = args[++i];
+    } else if (args[i] === '--until' && args[i + 1]) {
+      result.until = args[++i];
+    } else if (args[i] === '--json') {
+      result.json = true;
+    } else if (args[i] === '--save') {
+      result.save = true;
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Default date range (last 7 days)
+// ---------------------------------------------------------------------------
+
+function getDefaultDateRange() {
+  const now = new Date();
+  const since = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  return {
+    since: since.toISOString(),
+    until: now.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// gh CLI helpers (injectable for testing)
+// ---------------------------------------------------------------------------
+
+function defaultExecGh(cmd) {
+  return execSync(cmd, {
+    encoding: 'utf8',
+    timeout: 30_000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+function fetchClosedIssues(since, execGh) {
+  const cmd = `gh issue list --state closed --json number,title,createdAt,closedAt,labels --limit 100 --search "closed:>=${since}"`;
+  return JSON.parse(execGh(cmd));
+}
+
+function fetchAllIssues(since, execGh) {
+  const cmd = `gh issue list --state all --json number,title,createdAt,closedAt,state,labels --limit 100 --search "created:>=${since}"`;
+  return JSON.parse(execGh(cmd));
+}
+
+function fetchMergedPRs(since, execGh) {
+  const cmd = `gh pr list --state merged --json number,title,createdAt,mergedAt,closingIssuesReferences --limit 100 --search "merged:>=${since}"`;
+  return JSON.parse(execGh(cmd));
+}
+
+function fetchClosedPRs(since, execGh) {
+  const cmd = `gh pr list --state closed --json number,title,createdAt,mergedAt,closedAt --limit 100 --search "closed:>=${since}"`;
+  return JSON.parse(execGh(cmd));
+}
+
+function fetchTestCount(execGh) {
+  try {
+    const raw = execGh('npx vitest run --reporter=json 2>&1');
+    const data = JSON.parse(raw);
+    return data.numTotalTests || 0;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Metric computations
+// ---------------------------------------------------------------------------
+
+/**
+ * Velocity: issues closed per session (approximated as issues closed / days)
+ */
+function computeVelocity(closedIssues, since, until) {
+  const days = (new Date(until) - new Date(since)) / (1000 * 60 * 60 * 24);
+  const sessionDays = Math.max(days, 1);
+  const count = closedIssues.length;
+  return {
+    value: Math.round((count / sessionDays) * 100) / 100,
+    unit: 'issues/day',
+    raw: count,
+  };
+}
+
+/**
+ * Cycle time: average hours from issue creation to PR merge
+ */
+function computeCycleTime(mergedPRs) {
+  const cycleTimes = [];
+
+  for (const pr of mergedPRs) {
+    const refs = pr.closingIssuesReferences || [];
+    if (refs.length === 0) continue;
+
+    const mergedAt = new Date(pr.mergedAt);
+    for (const ref of refs) {
+      if (ref.createdAt) {
+        const created = new Date(ref.createdAt);
+        const hours = (mergedAt - created) / (1000 * 60 * 60);
+        if (hours >= 0) cycleTimes.push(hours);
+      }
+    }
+  }
+
+  if (cycleTimes.length === 0) {
+    return { value: null, unit: 'hours', raw: 0 };
+  }
+
+  const avg = cycleTimes.reduce((a, b) => a + b, 0) / cycleTimes.length;
+  return {
+    value: Math.round(avg * 100) / 100,
+    unit: 'hours',
+    raw: cycleTimes.length,
+  };
+}
+
+/**
+ * Quality rate: merge % vs rejection %
+ */
+function computeQualityRate(mergedPRs, closedPRs) {
+  // closedPRs includes both merged and rejected; filter out merged
+  const mergedNumbers = new Set(mergedPRs.map((pr) => pr.number));
+  const rejected = closedPRs.filter((pr) => !pr.mergedAt && !mergedNumbers.has(pr.number));
+  const total = mergedPRs.length + rejected.length;
+
+  if (total === 0) {
+    return { value: null, unit: '%', merged: 0, rejected: 0, total: 0 };
+  }
+
+  const rate = Math.round((mergedPRs.length / total) * 10000) / 100;
+  return {
+    value: rate,
+    unit: '%',
+    merged: mergedPRs.length,
+    rejected: rejected.length,
+    total,
+  };
+}
+
+/**
+ * Test growth: current test count
+ */
+function computeTestGrowth(testCount) {
+  return {
+    value: testCount,
+    unit: 'tests',
+  };
+}
+
+/**
+ * Throughput: PRs merged per day
+ */
+function computeThroughput(mergedPRs, since, until) {
+  const days = (new Date(until) - new Date(since)) / (1000 * 60 * 60 * 24);
+  const sessionDays = Math.max(days, 1);
+  const count = mergedPRs.length;
+  return {
+    value: Math.round((count / sessionDays) * 100) / 100,
+    unit: 'PRs/day',
+    raw: count,
+  };
+}
+
+/**
+ * Streak: consecutive days with at least one merged PR
+ */
+function computeStreak(mergedPRs) {
+  if (mergedPRs.length === 0) {
+    return { value: 0, unit: 'days' };
+  }
+
+  const mergeDates = new Set(
+    mergedPRs.map((pr) => pr.mergedAt.split('T')[0])
+  );
+
+  const sorted = [...mergeDates].sort().reverse();
+  let streak = 1;
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = new Date(sorted[i - 1]);
+    const curr = new Date(sorted[i]);
+    const diffDays = (prev - curr) / (1000 * 60 * 60 * 24);
+    if (Math.round(diffDays) === 1) {
+      streak++;
+    } else {
+      break;
+    }
+  }
+
+  return { value: streak, unit: 'days' };
+}
+
+// ---------------------------------------------------------------------------
+// Trend comparison
+// ---------------------------------------------------------------------------
+
+function computeTrend(current, previous) {
+  if (previous === null || previous === undefined || current === null || current === undefined) {
+    return 'NEW';
+  }
+  if (current > previous) return 'UP';
+  if (current < previous) return 'DOWN';
+  return 'FLAT';
+}
+
+function trendIndicator(trend) {
+  switch (trend) {
+    case 'UP': return '▲';
+    case 'DOWN': return '▼';
+    case 'FLAT': return '→';
+    case 'NEW': return '★';
+    default: return '?';
+  }
+}
+
+function compareWithPrevious(metrics, previousSnapshot) {
+  if (!previousSnapshot || !previousSnapshot.metrics) {
+    return Object.fromEntries(
+      Object.entries(metrics).map(([key, m]) => [key, 'NEW'])
+    );
+  }
+
+  const prev = previousSnapshot.metrics;
+  const trends = {};
+
+  for (const key of Object.keys(metrics)) {
+    const currVal = metrics[key].value;
+    const prevVal = prev[key] ? prev[key].value : null;
+    trends[key] = computeTrend(currVal, prevVal);
+  }
+
+  return trends;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot I/O
+// ---------------------------------------------------------------------------
+
+function getSnapshotPath(date) {
+  const dateStr = date.split('T')[0];
+  return path.join('docs', 'metrics', `${dateStr}.json`);
+}
+
+function loadPreviousSnapshot(snapshotDir, readFileFn) {
+  const readFile = readFileFn || ((p) => fs.readFileSync(p, 'utf8'));
+
+  let dir;
+  try {
+    dir = fs.readdirSync(snapshotDir);
+  } catch {
+    return null;
+  }
+
+  const jsonFiles = dir
+    .filter((f) => f.endsWith('.json'))
+    .sort()
+    .reverse();
+
+  if (jsonFiles.length === 0) return null;
+
+  try {
+    const content = readFile(path.join(snapshotDir, jsonFiles[0]));
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+function defaultWriteFile(filePath, content) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(filePath, content, 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// Human-readable table
+// ---------------------------------------------------------------------------
+
+function formatTable(metrics, trends) {
+  const rows = [
+    ['Metric', 'Value', 'Unit', 'Trend'],
+    ['──────────────', '──────', '──────────', '─────'],
+  ];
+
+  const labels = {
+    velocity: 'Velocity',
+    cycleTime: 'Cycle Time',
+    qualityRate: 'Quality Rate',
+    testGrowth: 'Test Growth',
+    throughput: 'Throughput',
+    streak: 'Streak',
+  };
+
+  for (const [key, label] of Object.entries(labels)) {
+    const m = metrics[key];
+    if (!m) continue;
+    const val = m.value !== null && m.value !== undefined ? String(m.value) : 'N/A';
+    const trend = trends[key] || 'NEW';
+    rows.push([label, val, m.unit, `${trendIndicator(trend)} ${trend}`]);
+  }
+
+  // Calculate column widths
+  const widths = rows[0].map((_, col) =>
+    Math.max(...rows.map((row) => (row[col] || '').length))
+  );
+
+  return rows.map((row) =>
+    row.map((cell, i) => (cell || '').padEnd(widths[i])).join('  ')
+  ).join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function run(argv, deps) {
+  const execGh = (deps && deps.execGh) || defaultExecGh;
+  const writeFile = (deps && deps.writeFile) || defaultWriteFile;
+  const readFile = deps && deps.readFile;
+  const snapshotDirOverride = deps && deps.snapshotDir;
+
+  const parsed = parseArgs(argv || process.argv);
+  const defaults = getDefaultDateRange();
+  const since = parsed.since || defaults.since;
+  const until = parsed.until || defaults.until;
+
+  // Fetch data
+  let closedIssues, allIssues, mergedPRs, closedPRs, testCount;
+
+  try {
+    closedIssues = fetchClosedIssues(since, execGh);
+  } catch (err) {
+    console.error(`Metrics: failed to fetch closed issues — ${err.message}`);
+    return { exitCode: 1 };
+  }
+
+  try {
+    allIssues = fetchAllIssues(since, execGh);
+  } catch (err) {
+    console.error(`Metrics: failed to fetch issues — ${err.message}`);
+    return { exitCode: 1 };
+  }
+
+  try {
+    mergedPRs = fetchMergedPRs(since, execGh);
+  } catch (err) {
+    console.error(`Metrics: failed to fetch merged PRs — ${err.message}`);
+    return { exitCode: 1 };
+  }
+
+  try {
+    closedPRs = fetchClosedPRs(since, execGh);
+  } catch (err) {
+    console.error(`Metrics: failed to fetch closed PRs — ${err.message}`);
+    return { exitCode: 1 };
+  }
+
+  try {
+    testCount = fetchTestCount(execGh);
+  } catch {
+    testCount = null;
+  }
+
+  // Compute metrics
+  const metrics = {
+    velocity: computeVelocity(closedIssues, since, until),
+    cycleTime: computeCycleTime(mergedPRs),
+    qualityRate: computeQualityRate(mergedPRs, closedPRs),
+    testGrowth: computeTestGrowth(testCount),
+    throughput: computeThroughput(mergedPRs, since, until),
+    streak: computeStreak(mergedPRs),
+  };
+
+  // Load previous snapshot for trend comparison
+  const snapshotDir = snapshotDirOverride || path.join('docs', 'metrics');
+  const previousSnapshot = loadPreviousSnapshot(snapshotDir, readFile);
+  const trends = compareWithPrevious(metrics, previousSnapshot);
+
+  const snapshot = {
+    since,
+    until,
+    generatedAt: new Date().toISOString(),
+    metrics,
+    trends,
+  };
+
+  // Output
+  if (parsed.json) {
+    console.log(JSON.stringify(snapshot, null, 2));
+  } else {
+    console.log('');
+    console.log('╔══════════════════════════════════════════════════╗');
+    console.log('║       Autonomous Performance Metrics             ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.log('');
+    console.log(`Period: ${since.split('T')[0]} → ${until.split('T')[0]}`);
+    console.log('');
+    console.log(formatTable(metrics, trends));
+    console.log('');
+
+    if (metrics.qualityRate.total > 0) {
+      console.log(`Quality: ${metrics.qualityRate.merged} merged, ${metrics.qualityRate.rejected} rejected of ${metrics.qualityRate.total} total`);
+    }
+    console.log('');
+  }
+
+  // Save snapshot
+  if (parsed.save) {
+    const snapshotPath = getSnapshotPath(until);
+    try {
+      writeFile(snapshotPath, JSON.stringify(snapshot, null, 2));
+      console.log(`Snapshot saved to: ${snapshotPath}`);
+    } catch (err) {
+      console.error(`Metrics: failed to save snapshot — ${err.message}`);
+      return { exitCode: 1 };
+    }
+  }
+
+  return { exitCode: 0, snapshot };
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+  run()
+    .then((result) => process.exit(result.exitCode))
+    .catch((err) => {
+      console.error('Metrics engine error:', err.message);
+      process.exit(1);
+    });
+}
+
+module.exports = {
+  parseArgs,
+  getDefaultDateRange,
+  fetchClosedIssues,
+  fetchAllIssues,
+  fetchMergedPRs,
+  fetchClosedPRs,
+  fetchTestCount,
+  computeVelocity,
+  computeCycleTime,
+  computeQualityRate,
+  computeTestGrowth,
+  computeThroughput,
+  computeStreak,
+  computeTrend,
+  trendIndicator,
+  compareWithPrevious,
+  getSnapshotPath,
+  loadPreviousSnapshot,
+  formatTable,
+  run,
+};

--- a/scripts/squad-cli.js
+++ b/scripts/squad-cli.js
@@ -14,6 +14,7 @@
  *   review   Run review gate on a PR (requires --pr <number>)
  *   dedup    Run dedup guard
  *   report   Generate session report
+ *   metrics  Run performance metrics engine
  *   help     Show this help message
  *
  * Flags:
@@ -27,7 +28,7 @@ const path = require('path');
 // Constants
 // ---------------------------------------------------------------------------
 
-const COMMANDS = ['status', 'health', 'review', 'dedup', 'report', 'help'];
+const COMMANDS = ['status', 'health', 'review', 'dedup', 'report', 'metrics', 'help'];
 
 const HELP_TEXT = `
 Squad CLI — Unified developer CLI for all squad operations
@@ -41,15 +42,20 @@ Commands:
   review --pr <num>   Run review gate on a PR
   dedup               Run dedup guard
   report              Generate session report
+  metrics             Run performance metrics engine
   help                Show this help message
 
 Flags:
   --json              Machine-readable JSON output (where supported)
+  --save              Save metrics snapshot (metrics command)
+  --since <date>      Start date filter (metrics, report)
+  --until <date>      End date filter (metrics, report)
 
 Examples:
   npm run squad -- status
   npm run squad -- health --json
   npm run squad -- review --pr 42
+  npm run squad -- metrics --json --save
 `.trim();
 
 // ---------------------------------------------------------------------------
@@ -61,6 +67,7 @@ function parseCliArgs(argv) {
   const command = args[0] || null;
   const flags = args.slice(1);
   const jsonMode = flags.includes('--json');
+  const save = flags.includes('--save');
 
   let pr = null;
   const prIdx = flags.indexOf('--pr');
@@ -68,7 +75,19 @@ function parseCliArgs(argv) {
     pr = parseInt(flags[prIdx + 1], 10);
   }
 
-  return { command, flags, jsonMode, pr };
+  let since = null;
+  const sinceIdx = flags.indexOf('--since');
+  if (sinceIdx !== -1 && flags[sinceIdx + 1]) {
+    since = flags[sinceIdx + 1];
+  }
+
+  let until = null;
+  const untilIdx = flags.indexOf('--until');
+  if (untilIdx !== -1 && flags[untilIdx + 1]) {
+    until = flags[untilIdx + 1];
+  }
+
+  return { command, flags, jsonMode, pr, save, since, until };
 }
 
 // ---------------------------------------------------------------------------
@@ -215,11 +234,30 @@ function cmdHelp() {
 }
 
 // ---------------------------------------------------------------------------
+// Command: metrics
+// ---------------------------------------------------------------------------
+
+function cmdMetrics(jsonMode, save, since, until) {
+  const scriptPath = path.resolve(__dirname, 'metrics-engine.js');
+  const args = [];
+  if (jsonMode) args.push('--json');
+  if (save) args.push('--save');
+  if (since) args.push('--since', since);
+  if (until) args.push('--until', until);
+
+  const result = spawnSync(process.execPath, [scriptPath, ...args], {
+    stdio: 'inherit',
+    timeout: 60_000,
+  });
+  return result.status || 0;
+}
+
+// ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
 
 function route(parsed) {
-  const { command, jsonMode, pr } = parsed;
+  const { command, jsonMode, pr, save, since, until } = parsed;
 
   if (!command) {
     console.log(HELP_TEXT);
@@ -246,6 +284,8 @@ function route(parsed) {
       return cmdDedup(jsonMode);
     case 'report':
       return cmdReport(jsonMode);
+    case 'metrics':
+      return cmdMetrics(jsonMode, save, since, until);
     case 'help':
       return cmdHelp();
     default:
@@ -277,6 +317,7 @@ module.exports = {
   cmdReview,
   cmdDedup,
   cmdReport,
+  cmdMetrics,
   cmdHelp,
   route,
   main,


### PR DESCRIPTION
## Summary

Autonomous performance metrics engine that aggregates GitHub data into KPIs.

**Closes #55**

## Changes

- **scripts/metrics-engine.js** — New metrics engine with DI pattern. Computes 6 KPIs:
  - **Velocity** — issues closed per day
  - **Cycle Time** — avg hours from issue creation to PR merge
  - **Quality Rate** — merge vs rejection percentage
  - **Test Growth** — current test count
  - **Throughput** — PRs merged per day
  - **Streak** — consecutive days with merged PRs
- **scripts/__tests__/metrics-engine.test.js** — 57 unit tests with DI-mocked gh CLI
- **scripts/squad-cli.js** — Added \metrics\ command with \--json\, \--save\, \--since\, \--until\ flags
- **package.json** — Added \
pm run metrics\ script

## CLI Usage

\\\ash
npm run metrics                          # Human-readable table
npm run metrics -- --json                # JSON output
npm run metrics -- --save                # Save to docs/metrics/YYYY-MM-DD.json
npm run squad -- metrics --json --save   # Via unified CLI
\\\

## Features

- Trend comparison against previous snapshot (▲ UP / ▼ DOWN / → FLAT / ★ NEW)
- Human-readable table with trend indicators
- No new dependencies
- DI pattern consistent with existing scripts (dedup-guard, review-gate, session-report)

## Tests

All 275 tests pass (57 new metrics tests + 218 existing).