### PR TITLE
feat: add one-command developer bootstrap

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -37,6 +37,26 @@ Adding a new downstream company (or repo) to the Syntax Sorcery constellation in
 
 ---
 
+## Quick Start — Developer Bootstrap
+
+For new developers, a single command validates all prerequisites, installs dependencies, checks structure health, and runs tests:
+
+```bash
+npm run setup
+```
+
+Options:
+
+| Flag | Effect |
+|------|--------|
+| `--skip-tests` | Skip test validation |
+| `--skip-health` | Skip constellation health check |
+| `--verbose` | Show full command output |
+
+If `gh` CLI is not installed, GitHub-dependent steps are skipped automatically.
+
+---
+
 ## 2. Prerequisites
 
 Before starting, ensure you have:

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "dedup:check": "node scripts/dedup-guard.js",
     "report:session": "node scripts/session-report.js",
     "metrics": "node scripts/metrics-engine.js",
+    "setup": "node scripts/bootstrap.js",
     "squad": "node scripts/squad-cli.js"
   },
   "repository": {

--- a/scripts/__tests__/bootstrap.test.js
+++ b/scripts/__tests__/bootstrap.test.js
@@ -1,0 +1,393 @@
+/**
+ * Tests for scripts/bootstrap.js
+ *
+ * Uses dependency injection to mock exec calls. No real shell commands run.
+ * Covers prerequisites, sequencing, graceful degradation, and CLI flags.
+ */
+
+const {
+  parseArgs,
+  checkNodeVersion,
+  checkGhCli,
+  checkGhAuth,
+  checkGitConfig,
+  runPrerequisites,
+  installDeps,
+  runValidateSquad,
+  runHealthCheck,
+  runTests,
+  run,
+} = require('../bootstrap');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockExec(overrides = {}) {
+  return (cmd) => {
+    if (cmd.includes('node --version')) return overrides.nodeVersion ?? 'v20.11.0\n';
+    if (cmd.includes('gh --version')) {
+      if (overrides.ghMissing) throw new Error('not found');
+      return overrides.ghVersion ?? 'gh version 2.45.0 (2026-03-01)\n';
+    }
+    if (cmd.includes('gh auth status')) {
+      if (overrides.ghAuthFail) throw new Error('not logged in');
+      return 'Logged in to github.com';
+    }
+    if (cmd.includes('git config user.name')) return overrides.gitName ?? 'Trinity\n';
+    if (cmd.includes('git config user.email')) return overrides.gitEmail ?? 'trinity@ss.dev\n';
+    if (cmd === 'npm ci') return 'added 150 packages\n';
+    if (cmd.includes('validate-squad')) {
+      if (overrides.validateFail) throw new Error('FAILED');
+      return 'ALL CHECKS PASSED\n';
+    }
+    if (cmd.includes('constellation-health')) {
+      if (overrides.healthFail) throw new Error('RED');
+      return 'All repos healthy!\n';
+    }
+    if (cmd === 'npm test') {
+      if (overrides.testFail) throw new Error('test failure');
+      return 'Tests  168 passed\n';
+    }
+    return '';
+  };
+}
+
+function silenceConsole() {
+  const spies = {
+    log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+    error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+  };
+  return spies;
+}
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe('parseArgs', () => {
+  it('returns all false by default', () => {
+    const result = parseArgs(['node', 'bootstrap.js']);
+    expect(result.skipTests).toBe(false);
+    expect(result.skipHealth).toBe(false);
+    expect(result.verbose).toBe(false);
+  });
+
+  it('parses --skip-tests flag', () => {
+    const result = parseArgs(['node', 'bootstrap.js', '--skip-tests']);
+    expect(result.skipTests).toBe(true);
+  });
+
+  it('parses --skip-health flag', () => {
+    const result = parseArgs(['node', 'bootstrap.js', '--skip-health']);
+    expect(result.skipHealth).toBe(true);
+  });
+
+  it('parses --verbose flag', () => {
+    const result = parseArgs(['node', 'bootstrap.js', '--verbose']);
+    expect(result.verbose).toBe(true);
+  });
+
+  it('parses multiple flags', () => {
+    const result = parseArgs(['node', 'bootstrap.js', '--skip-tests', '--skip-health', '--verbose']);
+    expect(result.skipTests).toBe(true);
+    expect(result.skipHealth).toBe(true);
+    expect(result.verbose).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Individual prerequisite checks
+// ---------------------------------------------------------------------------
+
+describe('checkNodeVersion', () => {
+  it('passes for Node >=18', () => {
+    const exec = () => 'v20.11.0';
+    expect(checkNodeVersion(exec)).toEqual({ ok: true, detail: 'v20.11.0' });
+  });
+
+  it('passes for Node 18 exactly', () => {
+    const exec = () => 'v18.0.0';
+    expect(checkNodeVersion(exec)).toEqual({ ok: true, detail: 'v18.0.0' });
+  });
+
+  it('fails for Node <18', () => {
+    const exec = () => 'v16.20.0';
+    const result = checkNodeVersion(exec);
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain('requires >=18');
+  });
+});
+
+describe('checkGhCli', () => {
+  it('passes when gh is installed', () => {
+    const exec = () => 'gh version 2.45.0 (2026-03-01)\nhttps://github.com/cli/cli';
+    const result = checkGhCli(exec);
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain('gh version');
+  });
+
+  it('fails when gh is not installed', () => {
+    const exec = () => { throw new Error('not found'); };
+    const result = checkGhCli(exec);
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain('not installed');
+  });
+});
+
+describe('checkGhAuth', () => {
+  it('passes when authenticated', () => {
+    const exec = () => 'Logged in';
+    expect(checkGhAuth(exec)).toEqual({ ok: true, detail: 'authenticated' });
+  });
+
+  it('fails when not authenticated', () => {
+    const exec = () => { throw new Error('not logged in'); };
+    const result = checkGhAuth(exec);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('checkGitConfig', () => {
+  it('passes when name and email are set', () => {
+    let callCount = 0;
+    const exec = () => {
+      callCount++;
+      return callCount === 1 ? 'Trinity' : 'trinity@ss.dev';
+    };
+    const result = checkGitConfig(exec);
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain('Trinity');
+  });
+
+  it('fails when name is empty', () => {
+    const exec = () => '';
+    const result = checkGitConfig(exec);
+    expect(result.ok).toBe(false);
+  });
+
+  it('fails when git config throws', () => {
+    const exec = () => { throw new Error('git not found'); };
+    const result = checkGitConfig(exec);
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runPrerequisites — sequencing and graceful degradation
+// ---------------------------------------------------------------------------
+
+describe('runPrerequisites', () => {
+  let spies;
+  beforeEach(() => { spies = silenceConsole(); });
+  afterEach(() => { spies.log.mockRestore(); spies.error.mockRestore(); });
+
+  it('passes when all prerequisites met', () => {
+    const result = runPrerequisites(mockExec(), false);
+    expect(result.ok).toBe(true);
+    expect(result.ghAvailable).toBe(true);
+  });
+
+  it('gracefully degrades when gh CLI is missing', () => {
+    const result = runPrerequisites(mockExec({ ghMissing: true }), false);
+    expect(result.ok).toBe(true);
+    expect(result.ghAvailable).toBe(false);
+  });
+
+  it('gracefully degrades when gh auth fails', () => {
+    const result = runPrerequisites(mockExec({ ghAuthFail: true }), false);
+    expect(result.ok).toBe(true);
+    expect(result.ghAvailable).toBe(false);
+  });
+
+  it('fails hard when Node version is too low', () => {
+    const result = runPrerequisites(mockExec({ nodeVersion: 'v16.0.0\n' }), false);
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step functions
+// ---------------------------------------------------------------------------
+
+describe('installDeps', () => {
+  let spies;
+  beforeEach(() => { spies = silenceConsole(); });
+  afterEach(() => { spies.log.mockRestore(); spies.error.mockRestore(); });
+
+  it('returns true on successful install', () => {
+    expect(installDeps(mockExec(), false)).toBe(true);
+  });
+
+  it('returns false when npm ci fails', () => {
+    const exec = () => { throw new Error('npm ERR!'); };
+    expect(installDeps(exec, false)).toBe(false);
+  });
+});
+
+describe('runValidateSquad', () => {
+  let spies;
+  beforeEach(() => { spies = silenceConsole(); });
+  afterEach(() => { spies.log.mockRestore(); spies.error.mockRestore(); });
+
+  it('returns true when validation passes', () => {
+    expect(runValidateSquad(mockExec(), false)).toBe(true);
+  });
+
+  it('returns false when validation fails', () => {
+    expect(runValidateSquad(mockExec({ validateFail: true }), false)).toBe(false);
+  });
+});
+
+describe('runHealthCheck', () => {
+  let spies;
+  beforeEach(() => { spies = silenceConsole(); });
+  afterEach(() => { spies.log.mockRestore(); spies.error.mockRestore(); });
+
+  it('returns true when health check passes', () => {
+    expect(runHealthCheck(mockExec(), false, true)).toBe(true);
+  });
+
+  it('skips when gh is not available', () => {
+    expect(runHealthCheck(mockExec(), false, false)).toBe(true);
+  });
+
+  it('returns false when health check fails', () => {
+    expect(runHealthCheck(mockExec({ healthFail: true }), false, true)).toBe(false);
+  });
+});
+
+describe('runTests', () => {
+  let spies;
+  beforeEach(() => { spies = silenceConsole(); });
+  afterEach(() => { spies.log.mockRestore(); spies.error.mockRestore(); });
+
+  it('returns true when tests pass', () => {
+    expect(runTests(mockExec(), false)).toBe(true);
+  });
+
+  it('returns false when tests fail', () => {
+    expect(runTests(mockExec({ testFail: true }), false)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run — full integration (mocked)
+// ---------------------------------------------------------------------------
+
+describe('run', () => {
+  let spies;
+  beforeEach(() => { spies = silenceConsole(); });
+  afterEach(() => { spies.log.mockRestore(); spies.error.mockRestore(); });
+
+  it('completes successfully with all steps', () => {
+    const result = run(['node', 'bootstrap.js'], {
+      exec: mockExec(),
+      existsSync: () => false,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(parseFloat(result.elapsed)).toBeGreaterThanOrEqual(0);
+  });
+
+  it('respects --skip-tests flag', () => {
+    const calls = [];
+    const exec = (cmd, opts) => {
+      calls.push(cmd);
+      return mockExec()(cmd, opts);
+    };
+    const result = run(['node', 'bootstrap.js', '--skip-tests'], {
+      exec,
+      existsSync: () => false,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(calls).not.toContain('npm test');
+  });
+
+  it('respects --skip-health flag', () => {
+    const calls = [];
+    const exec = (cmd, opts) => {
+      calls.push(cmd);
+      return mockExec()(cmd, opts);
+    };
+    const result = run(['node', 'bootstrap.js', '--skip-health'], {
+      exec,
+      existsSync: () => false,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(calls.some(c => c.includes('constellation-health'))).toBe(false);
+  });
+
+  it('fails at prerequisites for old Node', () => {
+    const result = run(['node', 'bootstrap.js'], {
+      exec: mockExec({ nodeVersion: 'v14.0.0\n' }),
+      existsSync: () => false,
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.step).toBe('prerequisites');
+  });
+
+  it('skips health check when gh CLI is missing (graceful degradation)', () => {
+    const calls = [];
+    const exec = (cmd, opts) => {
+      calls.push(cmd);
+      return mockExec({ ghMissing: true })(cmd, opts);
+    };
+    const result = run(['node', 'bootstrap.js'], {
+      exec,
+      existsSync: () => false,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(calls.some(c => c.includes('constellation-health'))).toBe(false);
+  });
+
+  it('fails when validate-squad fails', () => {
+    const result = run(['node', 'bootstrap.js'], {
+      exec: mockExec({ validateFail: true }),
+      existsSync: () => false,
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.step).toBe('validate-squad');
+  });
+
+  it('fails when tests fail', () => {
+    const result = run(['node', 'bootstrap.js'], {
+      exec: mockExec({ testFail: true }),
+      existsSync: () => false,
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.step).toBe('tests');
+  });
+
+  it('executes steps in correct order', () => {
+    const steps = [];
+    const exec = (cmd) => {
+      if (cmd.includes('node --version')) { steps.push('node-version'); return 'v20.0.0\n'; }
+      if (cmd.includes('gh --version')) { steps.push('gh-version'); return 'gh 2.45.0\n'; }
+      if (cmd.includes('gh auth')) { steps.push('gh-auth'); return 'ok'; }
+      if (cmd.includes('git config user.name')) { steps.push('git-name'); return 'T\n'; }
+      if (cmd.includes('git config user.email')) { steps.push('git-email'); return 't@t\n'; }
+      if (cmd === 'npm ci') { steps.push('npm-ci'); return ''; }
+      if (cmd.includes('validate-squad')) { steps.push('validate'); return ''; }
+      if (cmd.includes('constellation-health')) { steps.push('health'); return ''; }
+      if (cmd === 'npm test') { steps.push('test'); return '168 passed'; }
+      return '';
+    };
+    run(['node', 'bootstrap.js'], { exec, existsSync: () => false });
+
+    const ordered = [
+      'node-version', 'gh-version', 'gh-auth', 'git-name', 'git-email',
+      'npm-ci', 'validate', 'health', 'test',
+    ];
+    expect(steps).toEqual(ordered);
+  });
+
+  it('shows verbose output when --verbose is set', () => {
+    run(['node', 'bootstrap.js', '--verbose'], {
+      exec: mockExec(),
+      existsSync: () => false,
+    });
+    // Verbose mode includes command output — check console.log received it
+    const allOutput = spies.log.mock.calls.map(c => c[0]).join('\n');
+    expect(allOutput).toContain('added 150 packages');
+  });
+});

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -1,0 +1,334 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * One-command developer bootstrap for Syntax Sorcery.
+ *
+ * Validates prerequisites, installs dependencies, runs structure validation,
+ * health checks, and tests — all with step-by-step progress output.
+ *
+ * Usage:
+ *   node scripts/bootstrap.js
+ *   node scripts/bootstrap.js --skip-tests --skip-health --verbose
+ *   npm run setup
+ *
+ * CLI flags:
+ *   --skip-tests   Skip test validation step
+ *   --skip-health  Skip constellation health check
+ *   --verbose      Show full command output
+ *
+ * No new dependencies — uses only Node.js built-ins.
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const SITE_DIR = path.join(ROOT, 'site');
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  return {
+    skipTests: args.includes('--skip-tests'),
+    skipHealth: args.includes('--skip-health'),
+    verbose: args.includes('--verbose'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Output helpers
+// ---------------------------------------------------------------------------
+
+function log(msg) { console.log(msg); }
+function stepStart(label) { log(`\n⏳ ${label}...`); }
+function stepPass(label) { log(`✅ ${label}`); }
+function stepSkip(label, reason) { log(`⏭️  ${label} — skipped (${reason})`); }
+function stepFail(label, detail) { log(`❌ ${label}`); if (detail) log(`   ${detail}`); }
+
+// ---------------------------------------------------------------------------
+// Command runner (dependency-injectable for testing)
+// ---------------------------------------------------------------------------
+
+function defaultExec(cmd, opts = {}) {
+  return execSync(cmd, {
+    encoding: 'utf8',
+    timeout: 120_000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    cwd: opts.cwd || ROOT,
+    ...opts,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Prerequisite checks
+// ---------------------------------------------------------------------------
+
+function checkNodeVersion(exec) {
+  const raw = exec('node --version').trim();           // e.g. "v20.11.0"
+  const major = parseInt(raw.replace(/^v/, ''), 10);
+  if (isNaN(major) || major < 18) {
+    return { ok: false, detail: `Node ${raw} found — requires >=18` };
+  }
+  return { ok: true, detail: raw };
+}
+
+function checkGhCli(exec) {
+  try {
+    const raw = exec('gh --version').split('\n')[0].trim();
+    return { ok: true, detail: raw };
+  } catch {
+    return { ok: false, detail: 'gh CLI not installed' };
+  }
+}
+
+function checkGhAuth(exec) {
+  try {
+    exec('gh auth status');
+    return { ok: true, detail: 'authenticated' };
+  } catch {
+    return { ok: false, detail: 'gh auth not configured' };
+  }
+}
+
+function checkGitConfig(exec) {
+  try {
+    const name = exec('git config user.name').trim();
+    const email = exec('git config user.email').trim();
+    if (!name || !email) {
+      return { ok: false, detail: 'git user.name or user.email not set' };
+    }
+    return { ok: true, detail: `${name} <${email}>` };
+  } catch {
+    return { ok: false, detail: 'git config not available' };
+  }
+}
+
+function runPrerequisites(exec, verbose) {
+  stepStart('Checking prerequisites');
+  const checks = [
+    { label: 'Node >=18', fn: () => checkNodeVersion(exec) },
+    { label: 'GitHub CLI (gh)', fn: () => checkGhCli(exec) },
+    { label: 'gh auth', fn: () => checkGhAuth(exec) },
+    { label: 'git config', fn: () => checkGitConfig(exec) },
+  ];
+
+  let ghAvailable = true;
+  const results = [];
+
+  for (const check of checks) {
+    const result = check.fn();
+    results.push({ ...result, label: check.label });
+
+    if (result.ok) {
+      stepPass(`${check.label} ${verbose ? '(' + result.detail + ')' : ''}`);
+    } else {
+      // gh CLI and gh auth are soft failures (graceful degradation)
+      if (check.label === 'GitHub CLI (gh)' || check.label === 'gh auth') {
+        stepSkip(check.label, result.detail);
+        ghAvailable = false;
+      } else {
+        stepFail(check.label, result.detail);
+        return { ok: false, ghAvailable, results };
+      }
+    }
+  }
+
+  return { ok: true, ghAvailable, results };
+}
+
+// ---------------------------------------------------------------------------
+// Dependency installation
+// ---------------------------------------------------------------------------
+
+function installDeps(exec, verbose) {
+  stepStart('Installing dependencies (root)');
+  try {
+    const out = exec('npm ci', { cwd: ROOT });
+    if (verbose) log(out);
+    stepPass('Root dependencies installed');
+  } catch (e) {
+    stepFail('Root npm ci failed', e.message);
+    return false;
+  }
+
+  // Site dependencies (only if site/ has package.json)
+  const sitePkg = path.join(SITE_DIR, 'package.json');
+  if (fs.existsSync(sitePkg)) {
+    stepStart('Installing dependencies (site)');
+    try {
+      const out = exec('npm ci', { cwd: SITE_DIR });
+      if (verbose) log(out);
+      stepPass('Site dependencies installed');
+    } catch (e) {
+      stepFail('Site npm ci failed', e.message);
+      return false;
+    }
+  } else {
+    stepSkip('Site dependencies', 'no site/package.json found');
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Structure validation
+// ---------------------------------------------------------------------------
+
+function runValidateSquad(exec, verbose) {
+  stepStart('Validating .squad/ structure');
+  try {
+    const out = exec('node scripts/validate-squad.js', { cwd: ROOT });
+    if (verbose) log(out);
+    stepPass('.squad/ structure valid');
+    return true;
+  } catch (e) {
+    stepFail('.squad/ validation failed', e.stderr || e.message);
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Health check
+// ---------------------------------------------------------------------------
+
+function runHealthCheck(exec, verbose, ghAvailable) {
+  if (!ghAvailable) {
+    stepSkip('Constellation health check', 'gh CLI not available');
+    return true;
+  }
+  stepStart('Running constellation health check');
+  try {
+    const out = exec('node scripts/constellation-health.js', { cwd: ROOT });
+    if (verbose) log(out);
+    stepPass('Constellation health check passed');
+    return true;
+  } catch (e) {
+    stepFail('Constellation health check failed', e.stderr || e.message);
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test validation
+// ---------------------------------------------------------------------------
+
+function runTests(exec, verbose) {
+  stepStart('Running tests');
+  try {
+    const out = exec('npm test', { cwd: ROOT });
+    if (verbose) log(out);
+    // Try to extract test count from vitest output
+    const match = out.match(/(\d+)\s+passed/i);
+    const count = match ? match[1] : '?';
+    stepPass(`Tests passed (${count} tests)`);
+    return true;
+  } catch (e) {
+    stepFail('Tests failed', e.stderr || e.stdout || e.message);
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main run function (dependency-injectable for testing)
+// ---------------------------------------------------------------------------
+
+function run(argv, deps = {}) {
+  const exec = deps.exec || defaultExec;
+  const existsSync = deps.existsSync || fs.existsSync;
+  const startTime = Date.now();
+
+  const flags = parseArgs(argv);
+
+  log('');
+  log('╔══════════════════════════════════════════════════════════════╗');
+  log('║          SYNTAX SORCERY — Developer Bootstrap               ║');
+  log('╚══════════════════════════════════════════════════════════════╝');
+
+  // Step 1: Prerequisites
+  const prereqs = runPrerequisites(exec, flags.verbose);
+  if (!prereqs.ok) {
+    log('\n❌ Bootstrap failed at prerequisites.');
+    return { exitCode: 1, step: 'prerequisites' };
+  }
+
+  // Step 2: Install dependencies
+  // Override fs.existsSync for site/package.json check in tests
+  const origExists = fs.existsSync;
+  if (deps.existsSync) fs.existsSync = deps.existsSync;
+  const depsOk = installDeps(exec, flags.verbose);
+  if (deps.existsSync) fs.existsSync = origExists;
+  if (!depsOk) {
+    log('\n❌ Bootstrap failed at dependency installation.');
+    return { exitCode: 1, step: 'dependencies' };
+  }
+
+  // Step 3: Structure validation
+  const structureOk = runValidateSquad(exec, flags.verbose);
+  if (!structureOk) {
+    log('\n❌ Bootstrap failed at .squad/ validation.');
+    return { exitCode: 1, step: 'validate-squad' };
+  }
+
+  // Step 4: Health check
+  if (flags.skipHealth) {
+    stepSkip('Constellation health check', '--skip-health flag');
+  } else {
+    const healthOk = runHealthCheck(exec, flags.verbose, prereqs.ghAvailable);
+    if (!healthOk) {
+      log('\n❌ Bootstrap failed at health check.');
+      return { exitCode: 1, step: 'health-check' };
+    }
+  }
+
+  // Step 5: Tests
+  if (flags.skipTests) {
+    stepSkip('Test validation', '--skip-tests flag');
+  } else {
+    const testsOk = runTests(exec, flags.verbose);
+    if (!testsOk) {
+      log('\n❌ Bootstrap failed at test validation.');
+      return { exitCode: 1, step: 'tests' };
+    }
+  }
+
+  // Summary
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  log('\n' + '═'.repeat(62));
+  log(`✅ Bootstrap complete! (${elapsed}s)`);
+  log('');
+  log('  Next steps:');
+  log('    npm test          — run tests');
+  log('    npm run squad     — squad CLI');
+  log('    npm run metrics   — performance metrics');
+  log('');
+
+  return { exitCode: 0, elapsed };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+  const result = run(process.argv);
+  process.exit(result.exitCode);
+}
+
+module.exports = {
+  parseArgs,
+  checkNodeVersion,
+  checkGhCli,
+  checkGhAuth,
+  checkGitConfig,
+  runPrerequisites,
+  installDeps,
+  runValidateSquad,
+  runHealthCheck,
+  runTests,
+  run,
+};


### PR DESCRIPTION
## Summary

Implements one-command developer bootstrap (\
pm run setup\) for Syntax Sorcery.

### What's included
- \scripts/bootstrap.js\ — full bootstrap script with 5 steps:
  1. **Prerequisites**: Node >=18, gh CLI, gh auth, git config
  2. **Dependencies**: root + site npm ci
  3. **Structure validation**: validate-squad.js
  4. **Health check**: constellation-health.js
  5. **Test validation**: npm test
- Step-by-step progress with checkmarks and final summary with time elapsed
- Graceful degradation: skips GitHub-dependent steps if gh CLI not installed
- CLI flags: \--skip-tests\, \--skip-health\, \--verbose\`n- \
pm run setup\ script in package.json
- 37 unit tests covering prerequisites, sequencing, graceful degradation, and flags
- Updated docs/onboarding.md with Quick Start section
- Zero new dependencies

### Test results
345 tests passing (37 new + 308 existing)

Closes #56