### PR TITLE
feat: automated site deployment pipeline to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
     paths:
       - 'site/**'
-      - '.squad/decisions.md'
+      - 'docs/**'
       - '.github/workflows/deploy-site.yml'
   workflow_dispatch:
   schedule:
@@ -18,7 +18,7 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -29,23 +29,30 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: site/package-lock.json
-          
+
+      - name: Cache Astro build
+        uses: actions/cache@v4
+        with:
+          path: site/.astro
+          key: astro-${{ hashFiles('site/src/**', 'site/astro.config.mjs') }}
+          restore-keys: astro-
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
-        
+
       - name: Install dependencies
         run: npm ci
-        
+
       - name: Build
         run: npm run build
-        
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 **Autonomous software development company powered by AI agents**
 
 [![CI](https://github.com/jperezdelreal/Syntax-Sorcery/actions/workflows/ci.yml/badge.svg)](https://github.com/jperezdelreal/Syntax-Sorcery/actions/workflows/ci.yml)
+[![Deploy Site](https://github.com/jperezdelreal/Syntax-Sorcery/actions/workflows/deploy-site.yml/badge.svg)](https://github.com/jperezdelreal/Syntax-Sorcery/actions/workflows/deploy-site.yml)
 ![Tests](https://img.shields.io/badge/tests-168%20passing-brightgreen)
 ![Node](https://img.shields.io/badge/node-20-blue)
 ![License](https://img.shields.io/badge/license-ISC-blue)


### PR DESCRIPTION
## Summary

Closes #60 — Automated site deployment pipeline to GitHub Pages.

## Changes

### \.github/workflows/deploy-site.yml\
- **Path filter:** Triggers on \site/**\, \docs/**\, and workflow self-changes
- **Build caching:** npm via \ctions/setup-node@v4\ + Astro build cache via \ctions/cache@v4\
- **Concurrency:** \pages\ group with \cancel-in-progress: true\
- **Deploy:** OIDC via \ctions/deploy-pages@v4\
- **Manual trigger:** \workflow_dispatch\ enabled
- **Schedule:** Daily 2AM UTC auto-update retained

### \README.md\
- Added Deploy Site status badge

## Acceptance Criteria Checklist
- [x] Triggers on push to main with path filter (\site/**\, \docs/**\)
- [x] Build: \cd site && npm ci && npm run build\ → \site/dist/\
- [x] Deploy: \ctions/deploy-pages@v4\ with OIDC
- [x] Permissions: \pages:write\, \id-token:write\
- [x] Concurrency group: pages (cancel in-progress)
- [x] Build caching: npm + .astro cache
- [x] Status badge in README
- [x] Manual trigger via \workflow_dispatch\
- [x] No new dependencies — official GitHub Actions only