### PR TITLE
feat: #71 Auto-update test badge in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master, main]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   ci:
@@ -33,3 +33,25 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Run tests with JSON reporter
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+        run: npx vitest run --reporter=json > vitest-results.json
+
+      - name: Update test count badge
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+        run: node scripts/update-badge.js < vitest-results.json
+
+      - name: Commit badge update
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          COUNT=$(node -e "const d=require('./vitest-results.json'); console.log(d.numPassedTests)")
+          if git diff --cached --quiet; then
+            echo "No badge change — skipping commit."
+          else
+            git commit -m "chore: update test count badge to ${COUNT} passing [skip ci]"
+            git push
+          fi

--- a/scripts/__tests__/update-badge.test.js
+++ b/scripts/__tests__/update-badge.test.js
@@ -1,0 +1,75 @@
+/**
+ * Tests for scripts/update-badge.js
+ *
+ * Pure-function tests — no filesystem or stdin I/O needed.
+ * Uses vitest globals mode (vi, describe, it, expect are global).
+ */
+
+const { extractTestCount, replaceBadge } = require('../update-badge');
+
+// ---------------------------------------------------------------------------
+// extractTestCount
+// ---------------------------------------------------------------------------
+
+describe('extractTestCount', () => {
+  it('extracts numPassedTests from valid vitest JSON', () => {
+    const json = JSON.stringify({ numPassedTests: 200, numFailedTests: 0 });
+    expect(extractTestCount(json)).toBe(200);
+  });
+
+  it('returns zero when all tests are skipped', () => {
+    const json = JSON.stringify({ numPassedTests: 0, numFailedTests: 0 });
+    expect(extractTestCount(json)).toBe(0);
+  });
+
+  it('throws on missing numPassedTests', () => {
+    const json = JSON.stringify({ success: true });
+    expect(() => extractTestCount(json)).toThrow('Missing numPassedTests');
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => extractTestCount('not json')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replaceBadge
+// ---------------------------------------------------------------------------
+
+describe('replaceBadge', () => {
+  const readme = [
+    '# My Project',
+    '![Tests](https://img.shields.io/badge/tests-168%20passing-brightgreen)',
+    'Some other text.',
+  ].join('\n');
+
+  it('replaces the badge with the new count', () => {
+    const { updated, changed } = replaceBadge(readme, 200);
+    expect(changed).toBe(true);
+    expect(updated).toContain('tests-200%20passing-brightgreen');
+    expect(updated).not.toContain('tests-168%20passing');
+  });
+
+  it('reports no change when count matches', () => {
+    const { updated, changed } = replaceBadge(readme, 168);
+    expect(changed).toBe(false);
+    expect(updated).toBe(readme);
+  });
+
+  it('throws when badge pattern is not found', () => {
+    const noBadge = '# Project\nNo badge here.';
+    expect(() => replaceBadge(noBadge, 100)).toThrow('Test badge not found');
+  });
+
+  it('preserves surrounding content', () => {
+    const { updated } = replaceBadge(readme, 300);
+    expect(updated).toContain('# My Project');
+    expect(updated).toContain('Some other text.');
+  });
+
+  it('handles large test counts', () => {
+    const { updated, changed } = replaceBadge(readme, 9999);
+    expect(changed).toBe(true);
+    expect(updated).toContain('tests-9999%20passing-brightgreen');
+  });
+});

--- a/scripts/update-badge.js
+++ b/scripts/update-badge.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Update Badge — parses vitest JSON output and updates the test count badge
+ * in README.md.
+ *
+ * Usage:
+ *   npx vitest run --reporter=json 2>/dev/null | node scripts/update-badge.js
+ *   node scripts/update-badge.js < vitest-results.json
+ *
+ * Exit codes:
+ *   0 — badge updated or already current
+ *   1 — error (missing input, parse failure, README not found)
+ *
+ * No external dependencies.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Defaults (DI-friendly for testing)
+// ---------------------------------------------------------------------------
+
+const README_PATH = path.resolve(__dirname, '..', 'README.md');
+const BADGE_PATTERN = /!\[Tests\]\(https:\/\/img\.shields\.io\/badge\/tests-\d+%20passing-brightgreen\)/;
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts total test count from vitest JSON reporter output.
+ * @param {string} jsonStr — raw JSON from vitest --reporter=json
+ * @returns {number} total number of passing tests
+ */
+function extractTestCount(jsonStr) {
+  const data = JSON.parse(jsonStr);
+  if (typeof data.numPassedTests !== 'number') {
+    throw new Error('Missing numPassedTests in vitest JSON output');
+  }
+  return data.numPassedTests;
+}
+
+/**
+ * Replaces the test badge in README content with the new count.
+ * @param {string} content — README file content
+ * @param {number} count — test count to set
+ * @returns {{ updated: string, changed: boolean }}
+ */
+function replaceBadge(content, count) {
+  const newBadge = `![Tests](https://img.shields.io/badge/tests-${count}%20passing-brightgreen)`;
+  if (!BADGE_PATTERN.test(content)) {
+    throw new Error('Test badge not found in README.md');
+  }
+  const updated = content.replace(BADGE_PATTERN, newBadge);
+  return { updated, changed: updated !== content };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+async function main() {
+  // Read vitest JSON from stdin
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  const input = Buffer.concat(chunks).toString('utf8').trim();
+
+  if (!input) {
+    console.error('Error: No input received on stdin. Pipe vitest JSON output.');
+    process.exit(1);
+  }
+
+  let count;
+  try {
+    count = extractTestCount(input);
+  } catch (err) {
+    console.error(`Error parsing vitest JSON: ${err.message}`);
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(README_PATH)) {
+    console.error(`Error: README.md not found at ${README_PATH}`);
+    process.exit(1);
+  }
+
+  const content = fs.readFileSync(README_PATH, 'utf8');
+
+  let result;
+  try {
+    result = replaceBadge(content, count);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+
+  if (!result.changed) {
+    console.log(`Badge already shows ${count} passing — no update needed.`);
+    process.exit(0);
+  }
+
+  fs.writeFileSync(README_PATH, result.updated, 'utf8');
+  console.log(`Badge updated to ${count} passing.`);
+}
+
+// Allow testing without running main
+if (require.main === module) {
+  main();
+}
+
+module.exports = { extractTestCount, replaceBadge };


### PR DESCRIPTION
Closes #71

## What
CI now auto-updates the test count badge in README.md after tests pass on main/master.

## How
- \scripts/update-badge.js\ — parses vitest JSON output, replaces badge count in README
- CI workflow adds 3 steps (only on push to main/master):
  1. Run vitest with \--reporter=json\
  2. Pipe JSON to update-badge.js
  3. Commit + push if count changed (\[skip ci]\ prevents infinite loops)
- No new dependencies
- 9 new tests (408 total)