### PR TITLE
feat: #109 Dashboard metrics API

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "plugin": "node scripts/plugin-manager.js",
     "gameplay-test": "node scripts/gameplay-test/framework.js",
     "watch": "node scripts/squad-watch.js",
+    "dashboard:data": "node scripts/dashboard-api.js",
     "squad": "node scripts/squad-cli.js"
   },
   "repository": {

--- a/scripts/__tests__/dashboard-api.test.js
+++ b/scripts/__tests__/dashboard-api.test.js
@@ -1,0 +1,527 @@
+/**
+ * Tests for scripts/dashboard-api.js
+ *
+ * Mocks execGh via DI to avoid real gh CLI calls.
+ * Uses vitest globals mode.
+ */
+
+const {
+  OWNER,
+  CONSTELLATION_REPOS,
+  parseArgs,
+  safeExec,
+  fetchRepoIssues,
+  fetchRepoPRs,
+  fetchRepoCommits,
+  fetchLatestWorkflowRun,
+  computeIssuesOpened7d,
+  computeIssuesClosed7d,
+  computePRsMerged7d,
+  computePRsOpen,
+  computeAvgCycleTime,
+  computeActiveAgents,
+  computeLastActivity,
+  computeTestCount,
+  rate,
+  run,
+} = require('../dashboard-api');
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NOW = new Date('2026-07-30T12:00:00Z');
+const SINCE = new Date(NOW.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+function makeIssue(overrides = {}) {
+  return {
+    number: 1,
+    title: 'Test issue',
+    state: 'open',
+    created_at: '2026-07-28T10:00:00Z',
+    closed_at: null,
+    ...overrides,
+  };
+}
+
+function makePR(overrides = {}) {
+  return {
+    number: 10,
+    title: 'Test PR',
+    state: 'closed',
+    created_at: '2026-07-28T10:00:00Z',
+    merged_at: '2026-07-28T12:00:00Z',
+    closed_at: '2026-07-28T12:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeCommit(date = '2026-07-30T08:00:00Z') {
+  return {
+    sha: 'abc123',
+    commit: {
+      author: { date },
+      committer: { date },
+      message: 'test commit',
+    },
+  };
+}
+
+function makeWorkflowRun(overrides = {}) {
+  return {
+    id: 100,
+    name: 'CI Tests',
+    status: 'completed',
+    conclusion: 'success',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe('parseArgs', () => {
+  it('parses --json flag', () => {
+    const result = parseArgs(['node', 'dashboard-api.js', '--json']);
+    expect(result.json).toBe(true);
+    expect(result.output).toBeNull();
+  });
+
+  it('parses --output flag', () => {
+    const result = parseArgs(['node', 'dashboard-api.js', '--output', '/tmp/out.json']);
+    expect(result.output).toBe('/tmp/out.json');
+    expect(result.json).toBe(false);
+  });
+
+  it('parses both flags', () => {
+    const result = parseArgs(['node', 'dashboard-api.js', '--json', '--output', '/tmp/out.json']);
+    expect(result.json).toBe(true);
+    expect(result.output).toBe('/tmp/out.json');
+  });
+
+  it('returns defaults when no flags provided', () => {
+    const result = parseArgs(['node', 'dashboard-api.js']);
+    expect(result.json).toBe(false);
+    expect(result.output).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// safeExec
+// ---------------------------------------------------------------------------
+
+describe('safeExec', () => {
+  it('returns ok: true with parsed data on success', () => {
+    const mockExec = () => JSON.stringify({ count: 5 });
+    const result = safeExec('test cmd', mockExec);
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({ count: 5 });
+  });
+
+  it('returns ok: false on exec failure', () => {
+    const mockExec = () => { throw new Error('API rate limit'); };
+    const result = safeExec('test cmd', mockExec);
+    expect(result.ok).toBe(false);
+    expect(result.data).toBeNull();
+    expect(result.error).toContain('API rate limit');
+  });
+
+  it('returns ok: false on JSON parse error', () => {
+    const mockExec = () => 'not json';
+    const result = safeExec('test cmd', mockExec);
+    expect(result.ok).toBe(false);
+    expect(result.data).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchRepoIssues
+// ---------------------------------------------------------------------------
+
+describe('fetchRepoIssues', () => {
+  it('returns issues filtering out PRs', () => {
+    const issues = [
+      makeIssue({ number: 1 }),
+      { ...makeIssue({ number: 2 }), pull_request: { url: 'https://...' } },
+      makeIssue({ number: 3 }),
+    ];
+    const mockExec = () => JSON.stringify(issues);
+    const result = fetchRepoIssues('owner', 'repo', 'open', SINCE, mockExec);
+    expect(result).toHaveLength(2);
+    expect(result.map(i => i.number)).toEqual([1, 3]);
+  });
+
+  it('returns empty array on API failure', () => {
+    const mockExec = () => { throw new Error('fail'); };
+    const result = fetchRepoIssues('owner', 'repo', 'open', SINCE, mockExec);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchRepoPRs
+// ---------------------------------------------------------------------------
+
+describe('fetchRepoPRs', () => {
+  it('returns PRs array', () => {
+    const prs = [makePR({ number: 10 }), makePR({ number: 11 })];
+    const mockExec = () => JSON.stringify(prs);
+    const result = fetchRepoPRs('owner', 'repo', 'open', mockExec);
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty array on failure', () => {
+    const mockExec = () => { throw new Error('fail'); };
+    const result = fetchRepoPRs('owner', 'repo', 'open', mockExec);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchRepoCommits
+// ---------------------------------------------------------------------------
+
+describe('fetchRepoCommits', () => {
+  it('returns commits array', () => {
+    const commits = [makeCommit()];
+    const mockExec = () => JSON.stringify(commits);
+    const result = fetchRepoCommits('owner', 'repo', SINCE, mockExec);
+    expect(result).toHaveLength(1);
+    expect(result[0].sha).toBe('abc123');
+  });
+
+  it('returns empty array on failure', () => {
+    const mockExec = () => { throw new Error('fail'); };
+    const result = fetchRepoCommits('owner', 'repo', SINCE, mockExec);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchLatestWorkflowRun
+// ---------------------------------------------------------------------------
+
+describe('fetchLatestWorkflowRun', () => {
+  it('returns latest workflow run', () => {
+    const mockExec = () => JSON.stringify({ workflow_runs: [makeWorkflowRun()] });
+    const result = fetchLatestWorkflowRun('owner', 'repo', mockExec);
+    expect(result).not.toBeNull();
+    expect(result.name).toBe('CI Tests');
+  });
+
+  it('returns null when no runs exist', () => {
+    const mockExec = () => JSON.stringify({ workflow_runs: [] });
+    const result = fetchLatestWorkflowRun('owner', 'repo', mockExec);
+    expect(result).toBeNull();
+  });
+
+  it('returns null on failure', () => {
+    const mockExec = () => { throw new Error('fail'); };
+    const result = fetchLatestWorkflowRun('owner', 'repo', mockExec);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// KPI computations
+// ---------------------------------------------------------------------------
+
+describe('computeIssuesOpened7d', () => {
+  it('counts issues created within period', () => {
+    const data = {
+      repo1: [makeIssue({ created_at: '2026-07-28T10:00:00Z' })],
+      repo2: [makeIssue({ created_at: '2026-07-29T10:00:00Z' }), makeIssue({ created_at: '2026-07-15T10:00:00Z' })],
+    };
+    const count = computeIssuesOpened7d(data, SINCE);
+    expect(count).toBe(2); // only 2 within since window
+  });
+
+  it('returns 0 for empty data', () => {
+    expect(computeIssuesOpened7d({}, SINCE)).toBe(0);
+  });
+});
+
+describe('computeIssuesClosed7d', () => {
+  it('counts issues closed within period', () => {
+    const data = {
+      repo1: [makeIssue({ closed_at: '2026-07-28T10:00:00Z' }), makeIssue({ closed_at: null })],
+      repo2: [makeIssue({ closed_at: '2026-07-29T10:00:00Z' })],
+    };
+    const count = computeIssuesClosed7d(data, SINCE);
+    expect(count).toBe(2);
+  });
+
+  it('returns 0 for empty data', () => {
+    expect(computeIssuesClosed7d({}, SINCE)).toBe(0);
+  });
+});
+
+describe('computePRsMerged7d', () => {
+  it('counts PRs merged within period', () => {
+    const data = {
+      repo1: [makePR({ merged_at: '2026-07-28T12:00:00Z' }), makePR({ merged_at: null })],
+      repo2: [makePR({ merged_at: '2026-07-29T12:00:00Z' })],
+    };
+    const count = computePRsMerged7d(data, SINCE);
+    expect(count).toBe(2);
+  });
+
+  it('returns 0 for empty data', () => {
+    expect(computePRsMerged7d({}, SINCE)).toBe(0);
+  });
+});
+
+describe('computePRsOpen', () => {
+  it('sums open PRs across repos', () => {
+    const data = {
+      repo1: [makePR(), makePR()],
+      repo2: [makePR()],
+    };
+    expect(computePRsOpen(data)).toBe(3);
+  });
+
+  it('returns 0 for empty data', () => {
+    expect(computePRsOpen({})).toBe(0);
+  });
+});
+
+describe('computeAvgCycleTime', () => {
+  it('computes average hours from open to close', () => {
+    const data = {
+      repo1: [
+        makeIssue({ created_at: '2026-07-28T00:00:00Z', closed_at: '2026-07-28T06:00:00Z' }),
+        makeIssue({ created_at: '2026-07-28T00:00:00Z', closed_at: '2026-07-28T12:00:00Z' }),
+      ],
+    };
+    const avg = computeAvgCycleTime(data, SINCE);
+    expect(avg).toBe(9); // (6 + 12) / 2
+  });
+
+  it('returns null when no closed issues', () => {
+    const data = {
+      repo1: [makeIssue({ closed_at: null })],
+    };
+    expect(computeAvgCycleTime(data, SINCE)).toBeNull();
+  });
+
+  it('returns null for empty data', () => {
+    expect(computeAvgCycleTime({}, SINCE)).toBeNull();
+  });
+});
+
+describe('computeActiveAgents', () => {
+  it('counts repos with commits', () => {
+    const data = {
+      repo1: [makeCommit()],
+      repo2: [],
+      repo3: [makeCommit(), makeCommit()],
+    };
+    expect(computeActiveAgents(data)).toBe(2);
+  });
+
+  it('returns 0 for empty data', () => {
+    expect(computeActiveAgents({})).toBe(0);
+  });
+});
+
+describe('computeLastActivity', () => {
+  it('returns latest commit timestamp per repo', () => {
+    const data = {
+      repo1: [makeCommit('2026-07-30T08:00:00Z')],
+      repo2: [],
+    };
+    const activity = computeLastActivity(data);
+    expect(activity.repo1).toBe('2026-07-30T08:00:00Z');
+    expect(activity.repo2).toBeNull();
+  });
+});
+
+describe('computeTestCount', () => {
+  it('counts repos with workflow runs', () => {
+    const data = {
+      repo1: makeWorkflowRun(),
+      repo2: null,
+      repo3: makeWorkflowRun({ name: 'Build' }),
+    };
+    expect(computeTestCount(data)).toBe(2);
+  });
+
+  it('returns 0 when no CI runs', () => {
+    const data = { repo1: null, repo2: null };
+    expect(computeTestCount(data)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rate helper
+// ---------------------------------------------------------------------------
+
+describe('rate', () => {
+  it('computes count/day rate', () => {
+    expect(rate(14, 7)).toBe(2);
+    expect(rate(3, 7)).toBe(0.43);
+  });
+
+  it('handles zero days as 1', () => {
+    expect(rate(5, 0)).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe('constants', () => {
+  it('has correct owner', () => {
+    expect(OWNER).toBe('jperezdelreal');
+  });
+
+  it('has 6 constellation repos', () => {
+    expect(CONSTELLATION_REPOS).toHaveLength(6);
+    expect(CONSTELLATION_REPOS).toContain('Syntax-Sorcery');
+    expect(CONSTELLATION_REPOS).toContain('pixel-bounce');
+    expect(CONSTELLATION_REPOS).toContain('flora');
+    expect(CONSTELLATION_REPOS).toContain('ComeRosquillas');
+    expect(CONSTELLATION_REPOS).toContain('FirstFrameStudios');
+    expect(CONSTELLATION_REPOS).toContain('ffs-squad-monitor');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run() integration
+// ---------------------------------------------------------------------------
+
+describe('run()', () => {
+  function buildMockExecGh() {
+    return (cmd) => {
+      if (cmd.includes('/issues?')) {
+        return JSON.stringify([
+          makeIssue({ number: 1, created_at: '2026-07-28T10:00:00Z', closed_at: '2026-07-29T10:00:00Z' }),
+        ]);
+      }
+      if (cmd.includes('/pulls?')) {
+        return JSON.stringify([
+          makePR({ number: 10, merged_at: '2026-07-29T12:00:00Z' }),
+        ]);
+      }
+      if (cmd.includes('/commits?')) {
+        return JSON.stringify([makeCommit('2026-07-30T08:00:00Z')]);
+      }
+      if (cmd.includes('/actions/runs')) {
+        return JSON.stringify({ workflow_runs: [makeWorkflowRun()] });
+      }
+      return '[]';
+    };
+  }
+
+  it('produces dashboard JSON with --json flag', async () => {
+    const logs = [];
+    const origLog = console.log;
+    console.log = (...args) => logs.push(args.join(' '));
+
+    try {
+      const result = await run(['node', 'dashboard-api.js', '--json'], {
+        execGh: buildMockExecGh(),
+        repos: ['test-repo'],
+        owner: 'test-owner',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.dashboard).toBeDefined();
+      expect(result.dashboard.kpis).toBeDefined();
+      expect(result.dashboard.constellation.repos).toEqual(['test-repo']);
+      expect(result.dashboard.constellation.owner).toBe('test-owner');
+
+      // Should have printed JSON to stdout
+      const output = logs.join('\n');
+      const parsed = JSON.parse(output);
+      expect(parsed.kpis).toBeDefined();
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it('writes to output file with --output flag', async () => {
+    let writtenPath = null;
+    let writtenContent = null;
+
+    const result = await run(['node', 'dashboard-api.js', '--output', '/tmp/test-dash.json'], {
+      execGh: buildMockExecGh(),
+      writeFile: (p, c) => { writtenPath = p; writtenContent = c; },
+      repos: ['test-repo'],
+      owner: 'test-owner',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(writtenPath).toContain('test-dash.json');
+    expect(writtenContent).toBeTruthy();
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.kpis).toBeDefined();
+  });
+
+  it('writes default output when no flags', async () => {
+    let writtenPath = null;
+
+    const origLog = console.log;
+    console.log = () => {};
+
+    try {
+      const result = await run(['node', 'dashboard-api.js'], {
+        execGh: buildMockExecGh(),
+        writeFile: (p, c) => { writtenPath = p; },
+        repos: ['test-repo'],
+        owner: 'test-owner',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(writtenPath).toContain('dashboard.json');
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it('handles API failures gracefully', async () => {
+    const failExec = () => { throw new Error('API error'); };
+
+    const origLog = console.log;
+    console.log = () => {};
+
+    try {
+      const result = await run(['node', 'dashboard-api.js', '--json'], {
+        execGh: failExec,
+        repos: ['fail-repo'],
+        owner: 'test-owner',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.dashboard.kpis.issues_opened_7d.value).toBe(0);
+      expect(result.dashboard.kpis.prs_open.value).toBe(0);
+      expect(result.dashboard.kpis.active_agents.value).toBe(0);
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it('computes KPIs across multiple repos', async () => {
+    const origLog = console.log;
+    console.log = () => {};
+
+    try {
+      const result = await run(['node', 'dashboard-api.js', '--json'], {
+        execGh: buildMockExecGh(),
+        repos: ['repo1', 'repo2', 'repo3'],
+        owner: 'test-owner',
+      });
+
+      expect(result.exitCode).toBe(0);
+      const k = result.dashboard.kpis;
+      // 3 repos × 1 open PR each = 3 open
+      expect(k.prs_open.value).toBe(3);
+      // 3 repos × 1 commit each = 3 active
+      expect(k.active_agents.value).toBe(3);
+    } finally {
+      console.log = origLog;
+    }
+  });
+});

--- a/scripts/dashboard-api.js
+++ b/scripts/dashboard-api.js
@@ -1,0 +1,427 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Dashboard API — Multi-repo metrics aggregator for the Syntax Sorcery constellation.
+ *
+ * Fetches KPIs across all constellation repos via `gh api` CLI and outputs
+ * structured JSON for the real-time dashboard.
+ *
+ * Usage:
+ *   node scripts/dashboard-api.js
+ *   node scripts/dashboard-api.js --json
+ *   node scripts/dashboard-api.js --output site/public/data/dashboard.json
+ *
+ * Flags:
+ *   --json     Output JSON to stdout
+ *   --output   Write JSON to the specified file path
+ *
+ * Exit codes:
+ *   0 — success
+ *   1 — error
+ *
+ * Requires: gh CLI authenticated with repo scope.
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const OWNER = 'jperezdelreal';
+
+const CONSTELLATION_REPOS = [
+  'Syntax-Sorcery',
+  'pixel-bounce',
+  'flora',
+  'ComeRosquillas',
+  'FirstFrameStudios',
+  'ffs-squad-monitor',
+];
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const result = { json: false, output: null };
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--json') {
+      result.json = true;
+    } else if (args[i] === '--output' && args[i + 1]) {
+      result.output = args[++i];
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// gh API helpers (injectable for testing)
+// ---------------------------------------------------------------------------
+
+function defaultExecGh(cmd) {
+  return execSync(cmd, {
+    encoding: 'utf8',
+    timeout: 30_000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+function safeExec(cmd, execGh) {
+  try {
+    const raw = execGh(cmd);
+    return { ok: true, data: JSON.parse(raw) };
+  } catch (err) {
+    return { ok: false, data: null, error: err.message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Data fetchers (per-repo)
+// ---------------------------------------------------------------------------
+
+function fetchRepoIssues(owner, repo, state, since, execGh) {
+  const sinceISO = since.toISOString().split('T')[0];
+  const cmd = `gh api "repos/${owner}/${repo}/issues?state=${state}&since=${sinceISO}&per_page=100" --paginate`;
+  const result = safeExec(cmd, execGh);
+  if (!result.ok) return [];
+  // gh api --paginate may return array directly or array of arrays
+  const items = Array.isArray(result.data) ? result.data : [];
+  // Filter out PRs (GitHub API returns PRs in issues endpoint)
+  return items.filter(i => !i.pull_request);
+}
+
+function fetchRepoPRs(owner, repo, state, execGh) {
+  const cmd = `gh api "repos/${owner}/${repo}/pulls?state=${state}&per_page=100&sort=updated&direction=desc"`;
+  const result = safeExec(cmd, execGh);
+  if (!result.ok) return [];
+  return Array.isArray(result.data) ? result.data : [];
+}
+
+function fetchRepoCommits(owner, repo, since, execGh) {
+  const sinceISO = since.toISOString();
+  const cmd = `gh api "repos/${owner}/${repo}/commits?since=${sinceISO}&per_page=5"`;
+  const result = safeExec(cmd, execGh);
+  if (!result.ok) return [];
+  return Array.isArray(result.data) ? result.data : [];
+}
+
+function fetchLatestWorkflowRun(owner, repo, execGh) {
+  const cmd = `gh api "repos/${owner}/${repo}/actions/runs?per_page=1&status=completed"`;
+  const result = safeExec(cmd, execGh);
+  if (!result.ok || !result.data || !result.data.workflow_runs) return null;
+  return result.data.workflow_runs[0] || null;
+}
+
+// ---------------------------------------------------------------------------
+// KPI computations
+// ---------------------------------------------------------------------------
+
+function computeIssuesOpened7d(allRepoIssues, since) {
+  let count = 0;
+  for (const issues of Object.values(allRepoIssues)) {
+    for (const issue of issues) {
+      if (new Date(issue.created_at) >= since) count++;
+    }
+  }
+  return count;
+}
+
+function computeIssuesClosed7d(allRepoClosedIssues, since) {
+  let count = 0;
+  for (const issues of Object.values(allRepoClosedIssues)) {
+    for (const issue of issues) {
+      if (issue.closed_at && new Date(issue.closed_at) >= since) count++;
+    }
+  }
+  return count;
+}
+
+function computePRsMerged7d(allRepoPRs, since) {
+  let count = 0;
+  for (const prs of Object.values(allRepoPRs)) {
+    for (const pr of prs) {
+      if (pr.merged_at && new Date(pr.merged_at) >= since) count++;
+    }
+  }
+  return count;
+}
+
+function computePRsOpen(allRepoOpenPRs) {
+  let count = 0;
+  for (const prs of Object.values(allRepoOpenPRs)) {
+    count += prs.length;
+  }
+  return count;
+}
+
+function computeAvgCycleTime(allRepoClosedIssues, since) {
+  const cycleTimes = [];
+  for (const issues of Object.values(allRepoClosedIssues)) {
+    for (const issue of issues) {
+      if (issue.closed_at && new Date(issue.closed_at) >= since) {
+        const openedAt = new Date(issue.created_at);
+        const closedAt = new Date(issue.closed_at);
+        const hours = (closedAt - openedAt) / (1000 * 60 * 60);
+        if (hours >= 0) cycleTimes.push(hours);
+      }
+    }
+  }
+  if (cycleTimes.length === 0) return null;
+  const avg = cycleTimes.reduce((a, b) => a + b, 0) / cycleTimes.length;
+  return Math.round(avg * 100) / 100;
+}
+
+function computeActiveAgents(allRepoCommits) {
+  let active = 0;
+  for (const commits of Object.values(allRepoCommits)) {
+    if (commits.length > 0) active++;
+  }
+  return active;
+}
+
+function computeLastActivity(allRepoCommits) {
+  const activity = {};
+  for (const [repo, commits] of Object.entries(allRepoCommits)) {
+    if (commits.length > 0 && commits[0].commit) {
+      activity[repo] = commits[0].commit.committer
+        ? commits[0].commit.committer.date
+        : commits[0].commit.author.date;
+    } else {
+      activity[repo] = null;
+    }
+  }
+  return activity;
+}
+
+function computeTestCount(allWorkflowRuns) {
+  let total = 0;
+  let found = false;
+  for (const run of Object.values(allWorkflowRuns)) {
+    if (run && run.name && /test/i.test(run.name)) {
+      found = true;
+    }
+  }
+  // Test count from CI is unreliable without parsing logs; return repo count with CI
+  const reposWithCI = Object.values(allWorkflowRuns).filter(r => r !== null).length;
+  return reposWithCI;
+}
+
+// ---------------------------------------------------------------------------
+// Rate helpers
+// ---------------------------------------------------------------------------
+
+function rate(count, days) {
+  const d = Math.max(days, 1);
+  return Math.round((count / d) * 100) / 100;
+}
+
+// ---------------------------------------------------------------------------
+// Main aggregation
+// ---------------------------------------------------------------------------
+
+async function run(argv, deps) {
+  const execGh = (deps && deps.execGh) || defaultExecGh;
+  const writeFile = (deps && deps.writeFile) || defaultWriteFile;
+  const owner = (deps && deps.owner) || OWNER;
+  const repos = (deps && deps.repos) || CONSTELLATION_REPOS;
+
+  const parsed = parseArgs(argv || process.argv);
+
+  const now = new Date();
+  const since = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const days = 7;
+
+  // Collect data per repo
+  const allRepoOpenIssues = {};
+  const allRepoClosedIssues = {};
+  const allRepoOpenPRs = {};
+  const allRepoClosedPRs = {};
+  const allRepoCommits = {};
+  const allWorkflowRuns = {};
+  const errors = [];
+
+  for (const repo of repos) {
+    try {
+      allRepoOpenIssues[repo] = fetchRepoIssues(owner, repo, 'open', since, execGh);
+    } catch (e) {
+      allRepoOpenIssues[repo] = [];
+      errors.push({ repo, type: 'open_issues', error: e.message });
+    }
+
+    try {
+      allRepoClosedIssues[repo] = fetchRepoIssues(owner, repo, 'closed', since, execGh);
+    } catch (e) {
+      allRepoClosedIssues[repo] = [];
+      errors.push({ repo, type: 'closed_issues', error: e.message });
+    }
+
+    try {
+      allRepoOpenPRs[repo] = fetchRepoPRs(owner, repo, 'open', execGh);
+    } catch (e) {
+      allRepoOpenPRs[repo] = [];
+      errors.push({ repo, type: 'open_prs', error: e.message });
+    }
+
+    try {
+      allRepoClosedPRs[repo] = fetchRepoPRs(owner, repo, 'closed', execGh);
+    } catch (e) {
+      allRepoClosedPRs[repo] = [];
+      errors.push({ repo, type: 'closed_prs', error: e.message });
+    }
+
+    try {
+      const recentSince = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+      allRepoCommits[repo] = fetchRepoCommits(owner, repo, recentSince, execGh);
+    } catch (e) {
+      allRepoCommits[repo] = [];
+      errors.push({ repo, type: 'commits', error: e.message });
+    }
+
+    try {
+      allWorkflowRuns[repo] = fetchLatestWorkflowRun(owner, repo, execGh);
+    } catch (e) {
+      allWorkflowRuns[repo] = null;
+      errors.push({ repo, type: 'workflow', error: e.message });
+    }
+  }
+
+  // Compute KPIs
+  const issuesOpened7d = computeIssuesOpened7d(allRepoOpenIssues, since);
+  const issuesClosed7d = computeIssuesClosed7d(allRepoClosedIssues, since);
+  const prsMerged7d = computePRsMerged7d(allRepoClosedPRs, since);
+  const prsOpen = computePRsOpen(allRepoOpenPRs);
+  const avgCycleTime = computeAvgCycleTime(allRepoClosedIssues, since);
+  const activeAgents = computeActiveAgents(allRepoCommits);
+  const lastActivity = computeLastActivity(allRepoCommits);
+  const testCount = computeTestCount(allWorkflowRuns);
+
+  const dashboard = {
+    generatedAt: now.toISOString(),
+    period: {
+      since: since.toISOString(),
+      until: now.toISOString(),
+      days,
+    },
+    constellation: {
+      owner,
+      repos,
+      total: repos.length,
+    },
+    kpis: {
+      issues_opened_7d: { value: issuesOpened7d, rate: rate(issuesOpened7d, days), unit: 'issues/day' },
+      issues_closed_7d: { value: issuesClosed7d, rate: rate(issuesClosed7d, days), unit: 'issues/day' },
+      prs_merged_7d: { value: prsMerged7d, rate: rate(prsMerged7d, days), unit: 'PRs/day' },
+      prs_open: { value: prsOpen, unit: 'PRs' },
+      avg_cycle_time: { value: avgCycleTime, unit: 'hours' },
+      test_count: { value: testCount, unit: 'repos_with_ci' },
+      active_agents: { value: activeAgents, unit: 'repos', total: repos.length },
+    },
+    last_activity: lastActivity,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+
+  // Output
+  if (parsed.json) {
+    console.log(JSON.stringify(dashboard, null, 2));
+  } else if (parsed.output) {
+    const outputPath = path.resolve(parsed.output);
+    writeFile(outputPath, JSON.stringify(dashboard, null, 2));
+    console.log(`✓ Dashboard data written to ${outputPath}`);
+  } else {
+    // Default: human-readable summary + write to site/public/data/dashboard.json
+    printSummary(dashboard);
+    const defaultOutput = path.resolve(__dirname, '..', 'site', 'public', 'data', 'dashboard.json');
+    writeFile(defaultOutput, JSON.stringify(dashboard, null, 2));
+    console.log(`\n✓ Dashboard data written to ${defaultOutput}`);
+  }
+
+  return { exitCode: 0, dashboard };
+}
+
+// ---------------------------------------------------------------------------
+// Human-readable output
+// ---------------------------------------------------------------------------
+
+function printSummary(dashboard) {
+  const k = dashboard.kpis;
+  console.log('');
+  console.log('╔══════════════════════════════════════════════════╗');
+  console.log('║       Dashboard — Constellation Metrics          ║');
+  console.log('╚══════════════════════════════════════════════════╝');
+  console.log('');
+  console.log(`Period: ${dashboard.period.since.split('T')[0]} → ${dashboard.period.until.split('T')[0]} (${dashboard.period.days}d)`);
+  console.log(`Repos:  ${dashboard.constellation.total} in constellation`);
+  console.log('');
+  console.log(`  Issues opened (7d):    ${k.issues_opened_7d.value}  (${k.issues_opened_7d.rate}/day)`);
+  console.log(`  Issues closed (7d):    ${k.issues_closed_7d.value}  (${k.issues_closed_7d.rate}/day)`);
+  console.log(`  PRs merged (7d):       ${k.prs_merged_7d.value}  (${k.prs_merged_7d.rate}/day)`);
+  console.log(`  PRs open:              ${k.prs_open.value}`);
+  console.log(`  Avg cycle time:        ${k.avg_cycle_time.value !== null ? k.avg_cycle_time.value + 'h' : 'N/A'}`);
+  console.log(`  Repos with CI:         ${k.test_count.value}`);
+  console.log(`  Active repos (24h):    ${k.active_agents.value}/${k.active_agents.total}`);
+  console.log('');
+  console.log('  Last activity per repo:');
+  for (const [repo, ts] of Object.entries(dashboard.last_activity)) {
+    const label = ts ? new Date(ts).toLocaleString() : 'no recent activity';
+    console.log(`    ${repo}: ${label}`);
+  }
+
+  if (dashboard.errors && dashboard.errors.length > 0) {
+    console.log('');
+    console.log(`  ⚠ ${dashboard.errors.length} API error(s) encountered`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// File I/O
+// ---------------------------------------------------------------------------
+
+function defaultWriteFile(filePath, content) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(filePath, content, 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+  run()
+    .then((result) => process.exit(result.exitCode))
+    .catch((err) => {
+      console.error('Dashboard API error:', err.message);
+      process.exit(1);
+    });
+}
+
+module.exports = {
+  OWNER,
+  CONSTELLATION_REPOS,
+  parseArgs,
+  safeExec,
+  fetchRepoIssues,
+  fetchRepoPRs,
+  fetchRepoCommits,
+  fetchLatestWorkflowRun,
+  computeIssuesOpened7d,
+  computeIssuesClosed7d,
+  computePRsMerged7d,
+  computePRsOpen,
+  computeAvgCycleTime,
+  computeActiveAgents,
+  computeLastActivity,
+  computeTestCount,
+  rate,
+  printSummary,
+  run,
+};

--- a/scripts/squad-cli.js
+++ b/scripts/squad-cli.js
@@ -21,6 +21,7 @@
  *   plugin <subcmd>     Manage plugins (list, install, search, create, info)
  *   gameplay-test       Init gameplay test templates for downstream games
  *   watch <subcmd>      Local watchdog monitoring (list, status, check)
+ *   dashboard-data     Aggregate KPIs across constellation repos
  *   help     Show this help message
  *
  * Flags:
@@ -39,7 +40,7 @@ const path = require('path');
 // Constants
 // ---------------------------------------------------------------------------
 
-const COMMANDS = ['status', 'health', 'review', 'dedup', 'report', 'metrics', 'security', 'preflight', 'enforce-protection', 'plugin', 'gameplay-test', 'watch', 'help'];
+const COMMANDS = ['status', 'health', 'review', 'dedup', 'report', 'metrics', 'security', 'preflight', 'enforce-protection', 'plugin', 'gameplay-test', 'watch', 'dashboard-data', 'help'];
 
 const HELP_TEXT = `
 Squad CLI — Unified developer CLI for all squad operations
@@ -60,6 +61,7 @@ Commands:
   plugin <subcmd>     Manage plugins (list, install, search, create, info)
   gameplay-test       Init gameplay test templates for downstream games
   watch <subcmd>      Local watchdog monitoring (list, status, check)
+  dashboard-data      Aggregate KPIs across constellation repos
   help                Show this help message
 
 Flags:
@@ -461,6 +463,24 @@ function cmdGameplayTest(parsed) {
 }
 
 // ---------------------------------------------------------------------------
+// Command: dashboard-data
+// ---------------------------------------------------------------------------
+
+function cmdDashboardData(jsonMode, parsed) {
+  const scriptPath = path.resolve(__dirname, 'dashboard-api.js');
+  const args = [];
+  if (jsonMode) args.push('--json');
+  const output = extractFlag(parsed.flags, '--output');
+  if (output) args.push('--output', output);
+
+  const result = spawnSync(process.execPath, [scriptPath, ...args], {
+    stdio: 'inherit',
+    timeout: 300_000,
+  });
+  return result.status || 0;
+}
+
+// ---------------------------------------------------------------------------
 // Command: watch
 // ---------------------------------------------------------------------------
 
@@ -519,6 +539,8 @@ function route(parsed) {
       return cmdPlugin(parsed.flags);
     case 'gameplay-test':
       return cmdGameplayTest(parsed);
+    case 'dashboard-data':
+      return cmdDashboardData(jsonMode, parsed);
     case 'watch':
       return cmdWatch(parsed);
     case 'help':
@@ -560,6 +582,7 @@ module.exports = {
   cmdEnforceProtection,
   cmdPlugin,
   cmdGameplayTest,
+  cmdDashboardData,
   cmdWatch,
   cmdHelp,
   route,

--- a/site/package.json
+++ b/site/package.json
@@ -7,7 +7,7 @@
     "node": ">=22.12.0"
   },
   "scripts": {
-    "prebuild": "node scripts/generate-metrics.js",
+    "prebuild": "node scripts/generate-metrics.js && node scripts/generate-dashboard.js",
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",

--- a/site/scripts/generate-dashboard.js
+++ b/site/scripts/generate-dashboard.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Pre-build script: generates dashboard JSON for the site.
+ * Runs `node scripts/dashboard-api.js --json` from the root repo and writes
+ * output to site/public/data/dashboard.json for Astro/frontend to consume.
+ */
+
+import { execSync } from 'child_process';
+import { writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = join(__dirname, '..', '..');
+const outputDir = join(__dirname, '..', 'public', 'data');
+const outputPath = join(outputDir, 'dashboard.json');
+
+const FALLBACK_DASHBOARD = {
+  generatedAt: new Date().toISOString(),
+  period: {
+    since: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+    until: new Date().toISOString(),
+    days: 7,
+  },
+  constellation: {
+    owner: 'jperezdelreal',
+    repos: ['Syntax-Sorcery', 'pixel-bounce', 'flora', 'ComeRosquillas', 'FirstFrameStudios', 'ffs-squad-monitor'],
+    total: 6,
+  },
+  kpis: {
+    issues_opened_7d: { value: 0, rate: 0, unit: 'issues/day' },
+    issues_closed_7d: { value: 0, rate: 0, unit: 'issues/day' },
+    prs_merged_7d: { value: 0, rate: 0, unit: 'PRs/day' },
+    prs_open: { value: 0, unit: 'PRs' },
+    avg_cycle_time: { value: null, unit: 'hours' },
+    test_count: { value: 0, unit: 'repos_with_ci' },
+    active_agents: { value: 0, unit: 'repos', total: 6 },
+  },
+  last_activity: {},
+};
+
+function main() {
+  if (!existsSync(outputDir)) {
+    mkdirSync(outputDir, { recursive: true });
+  }
+
+  let dashboardJson;
+  try {
+    const raw = execSync('node scripts/dashboard-api.js --json', {
+      cwd: rootDir,
+      encoding: 'utf8',
+      timeout: 120_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    dashboardJson = JSON.parse(raw);
+  } catch (err) {
+    console.warn(`⚠ Dashboard data generation failed (${err.message}), using fallback data`);
+    dashboardJson = FALLBACK_DASHBOARD;
+  }
+
+  writeFileSync(outputPath, JSON.stringify(dashboardJson, null, 2), 'utf8');
+  console.log(`✓ Dashboard data written to ${outputPath}`);
+}
+
+main();


### PR DESCRIPTION
Closes #109

## Dashboard Backend — Metrics Engine & GitHub API Integration

Multi-repo KPI aggregator that feeds the real-time dashboard.

### New files
- **scripts/dashboard-api.js** — Fetches data from all 6 constellation repos via \gh api\, computes 7 KPIs (issues opened/closed 7d, PRs merged/open, avg cycle time, active repos, CI coverage), outputs JSON or writes \site/public/data/dashboard.json\
- **scripts/__tests__/dashboard-api.test.js** — 41 vitest tests with DI-mocked gh API calls
- **site/scripts/generate-dashboard.js** — Pre-build script with graceful fallback

### Modified files
- **scripts/squad-cli.js** — Added \dashboard-data\ subcommand
- **package.json** — Added \
pm run dashboard:data\ script
- **site/package.json** — Pre-build hook generates dashboard.json before Astro build

### Test results
730 tests passing across 21 test files.